### PR TITLE
Add transaction metadata

### DIFF
--- a/.changeset/wet-cougars-judge.md
+++ b/.changeset/wet-cougars-judge.md
@@ -1,0 +1,5 @@
+---
+'@starknet-react/core': minor
+---
+
+Add metadata to transaction

--- a/examples/starknet-react-next/src/components/IncrementCounter.tsx
+++ b/examples/starknet-react-next/src/components/IncrementCounter.tsx
@@ -13,7 +13,16 @@ export function IncrementCounter() {
 
   return (
     <div>
-      <button onClick={() => invoke({ args: ['0x1'] })}>Increment Counter by 1</button>
+      <button
+        onClick={() =>
+          invoke({
+            args: ['0x1'],
+            metadata: { method: 'incrementCounter', message: 'increment counter by 1' },
+          })
+        }
+      >
+        Increment Counter by 1
+      </button>
     </div>
   )
 }

--- a/examples/starknet-react-next/src/components/TransactionList.tsx
+++ b/examples/starknet-react-next/src/components/TransactionList.tsx
@@ -4,7 +4,9 @@ import React from 'react'
 function TransactionItem({ transaction }: { transaction: Transaction }) {
   return (
     <span>
-      {transaction.transactionHash} - {transaction.status}
+      <a href={`https://goerli.voyager.online/tx/${transaction.transactionHash}`}>
+        {transaction.metadata.method}: {transaction.metadata.message} - {transaction.status}
+      </a>
     </span>
   )
 }

--- a/examples/starknet-react-next/src/pages/token.tsx
+++ b/examples/starknet-react-next/src/pages/token.tsx
@@ -65,8 +65,9 @@ function MintToken() {
   const onMint = useCallback(() => {
     reset()
     if (account && !amountError) {
+      const message = `${amount.toString()} tokens to ${account}`
       const amountBn = bnToUint256(amount)
-      invoke({ args: [account, amountBn] })
+      invoke({ args: [account, amountBn], metadata: { method: 'mint', message } })
     }
   }, [account, amount])
 

--- a/packages/core/src/providers/transaction/model.ts
+++ b/packages/core/src/providers/transaction/model.ts
@@ -4,6 +4,7 @@ export interface TransactionSubmitted {
   status: TransactionStatus
   transactionHash: string
   address?: string
+  metadata?: any
 }
 
 export interface TransactionReceived {
@@ -11,6 +12,7 @@ export interface TransactionReceived {
   transaction: StarknetTransaction
   transactionHash: string
   lastUpdatedAt: number
+  metadata?: any
 }
 
 export type Transaction = TransactionSubmitted | TransactionReceived

--- a/packages/core/src/providers/transaction/reducer.ts
+++ b/packages/core/src/providers/transaction/reducer.ts
@@ -53,13 +53,14 @@ export function transactionManagerReducer(
       return state
     }
 
-    const [transactionIndex, _oldTransaction] = entry
+    const [transactionIndex, oldTransaction] = entry
 
     const newTransaction: Transaction = {
       status: action.transactionResponse.status,
       transaction: action.transactionResponse.transaction,
       transactionHash: action.transactionResponse.transaction['transaction_hash'],
       lastUpdatedAt: action.lastUpdatedAt,
+      metadata: oldTransaction.metadata,
     }
 
     return {


### PR DESCRIPTION
Fix #70. I decided to use a more generic `metadata` field to allow application developers store any type of data that makes sense for their application.