### PR TITLE
fix: wrong npm libs and misleading id/name

### DIFF
--- a/packages/core/src/connectors/base.ts
+++ b/packages/core/src/connectors/base.ts
@@ -2,10 +2,6 @@ import { AccountInterface } from 'starknet'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export abstract class Connector<Options = any> {
-  /** Unique connector id */
-  abstract readonly id: string
-  /** Connector name */
-  abstract readonly name: string
   /** Options to use with connector */
   readonly options: Options
 
@@ -21,4 +17,8 @@ export abstract class Connector<Options = any> {
   abstract connect(): Promise<AccountInterface>
   abstract disconnect(): Promise<void>
   abstract account(): Promise<AccountInterface>
+  /** Unique connector id */
+  abstract id(): string
+  /** Connector name */
+  abstract name(): string
 }

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -13,9 +13,6 @@ type InjectedConnectorOptions = {
 }
 
 export class InjectedConnector extends Connector<InjectedConnectorOptions> {
-  readonly id = 'injected'
-  readonly name = 'ArgentX'
-
   constructor(options: InjectedConnectorOptions = {}) {
     super({ options })
   }
@@ -78,6 +75,18 @@ export class InjectedConnector extends Connector<InjectedConnectorOptions> {
     return starknet.account
       ? Promise.resolve(starknet.account)
       : Promise.reject(new ConnectorNotConnectedError())
+  }
+
+  id(): string {
+    return getStarknet().id ?? 'injected'
+  }
+
+  name(): string {
+    if (!this.available()) {
+      throw new ConnectorNotFoundError()
+    }
+
+    return getStarknet().name
   }
 }
 

--- a/website/docs/demo.mdx
+++ b/website/docs/demo.mdx
@@ -10,7 +10,7 @@ You can find the contract [on Voyager](https://goerli.voyager.online/contract/0x
 
 :::info
 
-If you try to invoke the `incrementCounter` method without first connecting Argent-X,
+If you try to invoke the `incrementCounter` method without first connecting a StarkNet wallet,
 the transaction will fail instantly.
 
 :::

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -10,16 +10,16 @@ slug: /
 
 ## Getting Started
 
-1. Add `@starknet-react/core`, `@argent/get-starknet` and `starknet` to your dependencies.
+1. Add `@starknet-react/core`, `get-starknet` and `starknet` to your dependencies.
 
 ```
-yarn add @starknet-react/core @argent/get-starknet starknet
+yarn add @starknet-react/core get-starknet starknet
 ```
 
 Or with npm:
 
 ```
-npm install @starknet-react/core @argent/get-starknet starknet
+npm install @starknet-react/core get-starknet starknet
 ```
 
 2. Wrap your app with `StarknetProvider`
@@ -36,7 +36,7 @@ function App() {
 }
 ```
 
-3. Connect the wallet (needs Argent X StarkNet Wallet extension installed)
+3. Connect the wallet (needs StarkNet Wallet extension installed)
 
 ```typescript
 import { useStarknet, InjectedConnector } from '@starknet-react/core'
@@ -48,8 +48,8 @@ function YourComponent() {
     <div>
       {connectors.map((connector) =>
         connector.available() ? (
-          <button key={connector.id} onClick={() => connect(connector)}>
-            Connect {connector.name}
+          <button key={connector.id()} onClick={() => connect(connector)}>
+            Connect {connector.name()}
           </button>
         ) : null
       )}
@@ -72,8 +72,8 @@ function YourComponent() {
 
 ## Customizing the default provider
 
-StarkNet React uses the provider provided by Argent X so that users can select
-the current network from a familiar interface. When Argent X is not connected,
+StarkNet React uses the provider provided by `get-starknet` so that users can select
+the current network from a familiar interface. When a StarkNet wallet is not connected,
 StarkNet React uses a _default provider_. By default, the default provider is
 the same as the default provider provided by starknet.js. Developers can customize
 the default provider as follows:

--- a/website/src/components/Demo/index.tsx
+++ b/website/src/components/Demo/index.tsx
@@ -62,9 +62,9 @@ function DemoAccount() {
         !error &&
         connectors.map((connector) =>
           connector.available() ? (
-            <ActionRoot key={connector.id}>
-              <button key={connector.id} onClick={() => connect(connector)}>
-                Connect {connector.name}
+            <ActionRoot key={connector.id()}>
+              <button key={connector.id()} onClick={() => connect(connector)}>
+                Connect {connector.name()}
               </button>
             </ActionRoot>
           ) : null
@@ -72,7 +72,7 @@ function DemoAccount() {
       {error instanceof ConnectorNotFoundError && (
         <div>
           <p>
-            <a href="https://github.com/argentlabs/argent-x">Download Argent-X</a>
+            <button onClick={() => connect(connectors[0])}>Download StarkNet wallet</button>
           </p>
         </div>
       )}


### PR DESCRIPTION
1. generalize wallet refs in docs
2. injected connector `name` and `id` must be dynamic since connector could return diff wallets
3. fixing intro docs
4. fixing demo app