### PR TITLE
feat: add execute hook for multicall

### DIFF
--- a/.changeset/beige-papayas-talk.md
+++ b/.changeset/beige-papayas-talk.md
@@ -1,0 +1,5 @@
+---
+'@starknet-react/core': minor
+---
+
+Added execute hook to enable multicalls

--- a/examples/starknet-react-next/pages/multicall.tsx
+++ b/examples/starknet-react-next/pages/multicall.tsx
@@ -1,0 +1,31 @@
+import { useStarknet } from '@starknet-react/core'
+import type { NextPage } from 'next'
+import { ConnectWallet } from '~/components/ConnectWallet'
+import { UserBalance } from './token'
+import { TransactionList } from '~/components/TransactionList'
+import { DepositToken } from '~/components/DepositToken'
+
+
+const MulticallPage: NextPage = () => {
+    const { account } = useStarknet()
+
+    if (!account) {
+        return (
+          <div>
+            <p>Connect Wallet</p>
+            <ConnectWallet />
+          </div>
+        )
+    }
+
+    return (
+        <div>
+            <p>Connected: {account}</p>
+                <UserBalance />
+                <DepositToken />
+                <TransactionList />
+        </div>
+    )
+}
+
+export default MulticallPage

--- a/examples/starknet-react-next/pages/multicall.tsx
+++ b/examples/starknet-react-next/pages/multicall.tsx
@@ -5,27 +5,26 @@ import { UserBalance } from './token'
 import { TransactionList } from '~/components/TransactionList'
 import { DepositToken } from '~/components/DepositToken'
 
-
 const MulticallPage: NextPage = () => {
-    const { account } = useStarknet()
+  const { account } = useStarknet()
 
-    if (!account) {
-        return (
-          <div>
-            <p>Connect Wallet</p>
-            <ConnectWallet />
-          </div>
-        )
-    }
-
+  if (!account) {
     return (
-        <div>
-            <p>Connected: {account}</p>
-                <UserBalance />
-                <DepositToken />
-                <TransactionList />
-        </div>
+      <div>
+        <p>Connect Wallet</p>
+        <ConnectWallet />
+      </div>
     )
+  }
+
+  return (
+    <div>
+      <p>Connected: {account}</p>
+      <UserBalance />
+      <DepositToken />
+      <TransactionList />
+    </div>
+  )
 }
 
 export default MulticallPage

--- a/examples/starknet-react-next/pages/token.tsx
+++ b/examples/starknet-react-next/pages/token.tsx
@@ -7,7 +7,7 @@ import { ConnectWallet } from '~/components/ConnectWallet'
 import { TransactionList } from '~/components/TransactionList'
 import { useTokenContract } from '~/hooks/token'
 
-function UserBalance() {
+export function UserBalance() {
   const { account } = useStarknet()
   const { contract } = useTokenContract()
 

--- a/examples/starknet-react-next/src/components/DepositToken.tsx
+++ b/examples/starknet-react-next/src/components/DepositToken.tsx
@@ -1,16 +1,14 @@
 import { useStarknet, useStarknetExecute } from '@starknet-react/core'
 import { useState, useCallback, useMemo } from 'react'
 import { toBN } from 'starknet/dist/utils/number'
-import { bnToUint256} from 'starknet/dist/utils/uint256'
-import { stark } from 'starknet'
 
 export function DepositToken() {
   const { account } = useStarknet()
   const [amount, setAmount] = useState('')
   const [amountError, setAmountError] = useState<string | undefined>()
 
-  const tokenAddress = "0x07394cbe418daa16e42b87ba67372d4ab4a5df0b05c6e554d158458ce245bc10"
-  const bankAddress = "0x0185a8709eedfd3da1a0d4a0739e649ddbe9433a4ca32f63de8824e52f078cda"
+  const tokenAddress = '0x07394cbe418daa16e42b87ba67372d4ab4a5df0b05c6e554d158458ce245bc10'
+  const bankAddress = '0x0185a8709eedfd3da1a0d4a0739e649ddbe9433a4ca32f63de8824e52f078cda'
 
   const updateAmount = useCallback(
     (newAmount: string) => {
@@ -30,22 +28,22 @@ export function DepositToken() {
   const calls = [
     {
       contractAddress: tokenAddress,
-      entrypoint: "approve",
-      calldata: [toBN(bankAddress).toString(), amount, "0"]
+      entrypoint: 'approve',
+      calldata: [toBN(bankAddress).toString(), amount, '0'],
     },
     {
-      contractAddress: "0x0185a8709eedfd3da1a0d4a0739e649ddbe9433a4ca32f63de8824e52f078cda",
-      entrypoint: "deposit",
-      calldata: [toBN(tokenAddress).toString(), amount, "0"],
-    }
+      contractAddress: '0x0185a8709eedfd3da1a0d4a0739e649ddbe9433a4ca32f63de8824e52f078cda',
+      entrypoint: 'deposit',
+      calldata: [toBN(tokenAddress).toString(), amount, '0'],
+    },
   ]
 
-  const { data, loading, error, reset, execute } = useStarknetExecute({
+  const { loading, error, reset, execute } = useStarknetExecute({
     calls,
     metadata: {
       method: 'Approve and deposit',
-      message: 'Approve and deposit tokens'
-    }
+      message: 'Approve and deposit tokens',
+    },
   })
 
   const onDeposit = useCallback(() => {
@@ -62,8 +60,7 @@ export function DepositToken() {
 
   console.log(amount)
 
-
-  return(
+  return (
     <div>
       <h2>Deposit Tokens</h2>
       <p>

--- a/examples/starknet-react-next/src/components/DepositToken.tsx
+++ b/examples/starknet-react-next/src/components/DepositToken.tsx
@@ -27,19 +27,6 @@ export function DepositToken() {
     [setAmount]
   )
 
-  // const calls = [
-  //   {
-  //     contractAddress: tokenAddress,
-  //     entrypoint: "approve",
-  //     calldata: [toBN(bankAddress).toString(), bnToUint256(amount)]
-  //   },
-  //   {
-  //     contractAddress: "0x0185a8709eedfd3da1a0d4a0739e649ddbe9433a4ca32f63de8824e52f078cda",
-  //     entrypoint: "deposit",
-  //     calldata: [toBN(tokenAddress).toString(), bnToUint256(amount)],
-  //   }
-  // ]
-
   const calls = [
     {
       contractAddress: tokenAddress,

--- a/examples/starknet-react-next/src/components/DepositToken.tsx
+++ b/examples/starknet-react-next/src/components/DepositToken.tsx
@@ -1,0 +1,92 @@
+import { useStarknet, useStarknetExecute } from '@starknet-react/core'
+import { useState, useCallback, useMemo } from 'react'
+import { toBN } from 'starknet/dist/utils/number'
+import { bnToUint256} from 'starknet/dist/utils/uint256'
+import { stark } from 'starknet'
+
+export function DepositToken() {
+  const { account } = useStarknet()
+  const [amount, setAmount] = useState('')
+  const [amountError, setAmountError] = useState<string | undefined>()
+
+  const tokenAddress = "0x07394cbe418daa16e42b87ba67372d4ab4a5df0b05c6e554d158458ce245bc10"
+  const bankAddress = "0x0185a8709eedfd3da1a0d4a0739e649ddbe9433a4ca32f63de8824e52f078cda"
+
+  const updateAmount = useCallback(
+    (newAmount: string) => {
+      // soft-validate amount
+      setAmount(newAmount)
+      try {
+        toBN(newAmount)
+        setAmountError(undefined)
+      } catch (err) {
+        console.error(err)
+        setAmountError('Please input a valid number')
+      }
+    },
+    [setAmount]
+  )
+
+  // const calls = [
+  //   {
+  //     contractAddress: tokenAddress,
+  //     entrypoint: "approve",
+  //     calldata: [toBN(bankAddress).toString(), bnToUint256(amount)]
+  //   },
+  //   {
+  //     contractAddress: "0x0185a8709eedfd3da1a0d4a0739e649ddbe9433a4ca32f63de8824e52f078cda",
+  //     entrypoint: "deposit",
+  //     calldata: [toBN(tokenAddress).toString(), bnToUint256(amount)],
+  //   }
+  // ]
+
+  const calls = [
+    {
+      contractAddress: tokenAddress,
+      entrypoint: "approve",
+      calldata: [toBN(bankAddress).toString(), amount, "0"]
+    },
+    {
+      contractAddress: "0x0185a8709eedfd3da1a0d4a0739e649ddbe9433a4ca32f63de8824e52f078cda",
+      entrypoint: "deposit",
+      calldata: [toBN(tokenAddress).toString(), amount, "0"],
+    }
+  ]
+
+  const { data, loading, error, reset, execute } = useStarknetExecute({
+    calls,
+    metadata: {
+      method: 'Approve and deposit',
+      message: 'Approve and deposit tokens'
+    }
+  })
+
+  const onDeposit = useCallback(() => {
+    reset()
+    if (account && !amountError) {
+      execute()
+    }
+  }, [account, amount, amountError, execute, reset])
+
+  const depositButtonDisabled = useMemo(() => {
+    if (loading) return true
+    return !account || !!amountError
+  }, [loading, account, amountError])
+
+  console.log(amount)
+
+
+  return(
+    <div>
+      <h2>Deposit Tokens</h2>
+      <p>
+        <span>Amount: </span>
+        <input type="number" onChange={(evt) => updateAmount(evt.target.value)} />
+      </p>
+      <button disabled={depositButtonDisabled} onClick={onDeposit}>
+        {loading ? 'Waiting for wallet' : 'Deposit'}
+      </button>
+      {error && <p>Error: {error}</p>}
+    </div>
+  )
+}

--- a/packages/core/src/hooks/execute.ts
+++ b/packages/core/src/hooks/execute.ts
@@ -1,0 +1,139 @@
+import { useCallback, useReducer } from 'react'
+import type { AccountInterface } from 'starknet'
+import { AddTransactionResponse, Overrides } from 'starknet'
+import { useStarknet, useStarknetTransactionManager } from '..'
+
+interface State {
+    data?: string
+    loading: boolean
+    error?: string
+}
+
+interface StartExecute {
+    type: 'start_execute'
+  }
+  
+  interface SetExecuteResponse {
+    type: 'set_execute_response'
+    data: AddTransactionResponse
+  }
+  
+  interface SetExecuteError {
+    type: 'set_execute_error'
+    error: string
+  }
+
+interface Reset {
+    type: 'reset'
+}
+
+type Action = StartExecute | SetExecuteResponse | SetExecuteError | Reset
+
+function starknetExecuteReducer(state: State, action: Action): State {
+  if (action.type === 'start_execute') {
+    return {
+      ...state,
+      loading: true,
+    }
+  } else if (action.type === 'set_execute_response') {
+    return {
+      ...state,
+      data: action.data.transaction_hash,
+      error: undefined,
+      loading: false,
+    }
+  } else if (action.type === 'set_execute_error') {
+    return {
+      ...state,
+      error: action.error,
+      loading: false,
+    }
+  } else if (action.type === 'reset') {
+    return {
+      ...state,
+      data: undefined,
+      error: undefined,
+      loading: false,
+    }
+  }
+  return state
+}
+
+interface Call {
+    contractAddress: string;
+    entrypoint: string;
+    calldata: unknown[];
+}
+
+interface UseStarknetExecuteArgs {
+    calls?: Call | Call[];
+    metadata?: any
+}
+
+export interface ExecuteArgs<T extends unknown[]> {
+    args: T
+    overrides?: Overrides
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    metadata?: any
+  }
+
+export interface UseStarknetExecute<T extends unknown[]> {
+    data?: string
+    loading: boolean
+    error?: string
+    reset: () => void
+    execute: () => Promise<AddTransactionResponse | undefined>
+  }
+
+export function useStarknetExecute<T extends unknown[]>({
+    calls,
+    metadata
+}: UseStarknetExecuteArgs): UseStarknetExecute<T> {
+    const { addTransaction } = useStarknetTransactionManager()
+    const [ state, dispatch] = useReducer(starknetExecuteReducer, {
+        loading: false
+    })
+
+    const { account: accountAddress, connectors } = useStarknet()
+
+    const reset = useCallback(() => {
+        dispatch({ type: 'reset' })
+    }, [dispatch])
+
+    const execute = useCallback(
+        async () => {
+          if (calls) {
+            try {
+              let accountInterface: AccountInterface | null = null
+              for (const connector of connectors) {
+                const account = await connector.account()
+                if (account.address === accountAddress) {
+                  accountInterface = account
+                  break
+                }
+              }
+              if (!accountInterface) {
+                throw new Error(`No connector for address ${accountAddress}`)
+              }
+              dispatch({ type: 'start_execute' })
+              const response = await accountInterface.execute(calls)
+              dispatch({ type: 'set_execute_response', data: response })
+              // start tracking the transaction
+              addTransaction({
+                status: response.code,
+                transactionHash: response.transaction_hash,
+                metadata,
+              })
+            } catch (err) {
+              const message = err instanceof Error ? err.message : String(err)
+              dispatch({ type: 'set_execute_error', error: message })
+            }
+          }
+          return undefined
+        },
+        [accountAddress, connectors, addTransaction]
+    )
+
+    return { data: state.data, loading: state.loading, error: state.error, reset, execute }
+}
+

--- a/packages/core/src/hooks/execute.ts
+++ b/packages/core/src/hooks/execute.ts
@@ -1,6 +1,6 @@
 import { useCallback, useReducer } from 'react'
 import type { AccountInterface } from 'starknet'
-import { AddTransactionResponse, Overrides } from 'starknet'
+import { AddTransactionResponse } from 'starknet'
 import { useStarknet, useStarknetTransactionManager } from '..'
 
 interface State {
@@ -67,13 +67,6 @@ interface Call {
 
 interface UseStarknetExecuteArgs {
   calls?: Call | Call[]
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  metadata?: any
-}
-
-export interface ExecuteArgs<T extends unknown[]> {
-  args: T
-  overrides?: Overrides
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   metadata?: any
 }

--- a/packages/core/src/hooks/execute.ts
+++ b/packages/core/src/hooks/execute.ts
@@ -4,27 +4,27 @@ import { AddTransactionResponse, Overrides } from 'starknet'
 import { useStarknet, useStarknetTransactionManager } from '..'
 
 interface State {
-    data?: string
-    loading: boolean
-    error?: string
+  data?: string
+  loading: boolean
+  error?: string
 }
 
 interface StartExecute {
-    type: 'start_execute'
-  }
-  
-  interface SetExecuteResponse {
-    type: 'set_execute_response'
-    data: AddTransactionResponse
-  }
-  
-  interface SetExecuteError {
-    type: 'set_execute_error'
-    error: string
-  }
+  type: 'start_execute'
+}
+
+interface SetExecuteResponse {
+  type: 'set_execute_response'
+  data: AddTransactionResponse
+}
+
+interface SetExecuteError {
+  type: 'set_execute_error'
+  error: string
+}
 
 interface Reset {
-    type: 'reset'
+  type: 'reset'
 }
 
 type Action = StartExecute | SetExecuteResponse | SetExecuteError | Reset
@@ -60,80 +60,74 @@ function starknetExecuteReducer(state: State, action: Action): State {
 }
 
 interface Call {
-    contractAddress: string;
-    entrypoint: string;
-    calldata: unknown[];
+  contractAddress: string
+  entrypoint: string
+  calldata: unknown[]
 }
 
 interface UseStarknetExecuteArgs {
-    calls?: Call | Call[];
-    metadata?: any
+  calls?: Call | Call[]
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  metadata?: any
 }
 
 export interface ExecuteArgs<T extends unknown[]> {
-    args: T
-    overrides?: Overrides
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    metadata?: any
-  }
-
-export interface UseStarknetExecute<T extends unknown[]> {
-    data?: string
-    loading: boolean
-    error?: string
-    reset: () => void
-    execute: () => Promise<AddTransactionResponse | undefined>
-  }
-
-export function useStarknetExecute<T extends unknown[]>({
-    calls,
-    metadata
-}: UseStarknetExecuteArgs): UseStarknetExecute<T> {
-    const { addTransaction } = useStarknetTransactionManager()
-    const [ state, dispatch] = useReducer(starknetExecuteReducer, {
-        loading: false
-    })
-
-    const { account: accountAddress, connectors } = useStarknet()
-
-    const reset = useCallback(() => {
-        dispatch({ type: 'reset' })
-    }, [dispatch])
-
-    const execute = useCallback(
-        async () => {
-          if (calls) {
-            try {
-              let accountInterface: AccountInterface | null = null
-              for (const connector of connectors) {
-                const account = await connector.account()
-                if (account.address === accountAddress) {
-                  accountInterface = account
-                  break
-                }
-              }
-              if (!accountInterface) {
-                throw new Error(`No connector for address ${accountAddress}`)
-              }
-              dispatch({ type: 'start_execute' })
-              const response = await accountInterface.execute(calls)
-              dispatch({ type: 'set_execute_response', data: response })
-              // start tracking the transaction
-              addTransaction({
-                status: response.code,
-                transactionHash: response.transaction_hash,
-                metadata,
-              })
-            } catch (err) {
-              const message = err instanceof Error ? err.message : String(err)
-              dispatch({ type: 'set_execute_error', error: message })
-            }
-          }
-          return undefined
-        },
-        [accountAddress, connectors, addTransaction]
-    )
-
-    return { data: state.data, loading: state.loading, error: state.error, reset, execute }
+  args: T
+  overrides?: Overrides
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  metadata?: any
 }
 
+export interface UseStarknetExecute {
+  data?: string
+  loading: boolean
+  error?: string
+  reset: () => void
+  execute: () => Promise<AddTransactionResponse | undefined>
+}
+
+export function useStarknetExecute({ calls, metadata }: UseStarknetExecuteArgs) {
+  const { addTransaction } = useStarknetTransactionManager()
+  const [state, dispatch] = useReducer(starknetExecuteReducer, {
+    loading: false,
+  })
+
+  const { account: accountAddress, connectors } = useStarknet()
+
+  const reset = useCallback(() => {
+    dispatch({ type: 'reset' })
+  }, [dispatch])
+
+  const execute = useCallback(async () => {
+    if (calls) {
+      try {
+        let accountInterface: AccountInterface | null = null
+        for (const connector of connectors) {
+          const account = await connector.account()
+          if (account.address === accountAddress) {
+            accountInterface = account
+            break
+          }
+        }
+        if (!accountInterface) {
+          throw new Error(`No connector for address ${accountAddress}`)
+        }
+        dispatch({ type: 'start_execute' })
+        const response = await accountInterface.execute(calls)
+        dispatch({ type: 'set_execute_response', data: response })
+        // start tracking the transaction
+        addTransaction({
+          status: response.code,
+          transactionHash: response.transaction_hash,
+          metadata,
+        })
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        dispatch({ type: 'set_execute_error', error: message })
+      }
+    }
+    return undefined
+  }, [accountAddress, connectors, addTransaction])
+
+  return { data: state.data, loading: state.loading, error: state.error, reset, execute }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
 
   examples/starknet-react-next:
     specifiers:
-      '@starknet-react/core': workspace:^
+      '@starknet-react/core': ^0.12.0
       '@types/node': 17.0.39
       '@types/react': 18.0.11
       '@types/react-dom': 18.0.5

--- a/website/docs/hooks/execute.md
+++ b/website/docs/hooks/execute.md
@@ -1,0 +1,44 @@
+---
+sidebar_position: 5
+---
+
+# useStarknetExecute
+
+Hook to create a function that executes an account with a list of calls and tracks the transaction status.
+
+```typescript
+import { useStarknetExecute } from '@starknet-react/core'
+
+const { data, loading, error, reset, execute } = useStarknetExecute({ calls, metadata })
+```
+
+## Parameters
+
+```typescript
+{
+  calls?: Call | Call[]
+  metadata?: any
+}
+```
+
+Where `Call`
+
+```typescript
+{
+  contractAddress: string
+  entrypoint: string
+  calldata: unknown[]
+}
+```
+
+## Return Values
+
+```typescript
+  data?: string
+  loading: boolean
+  error?: string
+  reset: () => void
+  execute: () => Promise<AddTransactionResponse | undefined>
+```
+
+Where `data` is the transaction hash and `AddTransactionResponse` is from starknet.js.


### PR DESCRIPTION
Based on the discussions that have happened in #102 I have created a useStarknetExecute hook enabling multicalls.

Calls need to be defined when creating the hook, and not on submit. Similar to how useSignTypedData is done.

```
const { data, loading, error, reset, execute } = useStarknetExecute({
  calls,
  metadata
})
```

Currently formatting the calldata in calls is up to the UI to implement. I have made an example in next react app that does this. This is an example of an approval and deposit made to a bank contract.

The calls are also not currently view exposed for a 'tx cart' yet, this would be up to the UI to handle separately. Although definitely would want to try implement in the future.

- [x] pnpm changeset
- [x] pnpm lint