### PR TITLE
Add the ability to pass blockNumber to contract call method

### DIFF
--- a/.changeset/pink-worms-flow.md
+++ b/.changeset/pink-worms-flow.md
@@ -1,0 +1,5 @@
+---
+'@starknet-react/core': patch
+---
+
+Add the ability to pass blockNumber to contract call method

--- a/packages/core/src/hooks/call.ts
+++ b/packages/core/src/hooks/call.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useReducer } from 'react'
-import { ContractInterface } from 'starknet'
+import { ContractInterface, BlockNumber } from 'starknet'
 import { useStarknetBlock } from '../providers/block'
 
 interface State {
@@ -54,6 +54,7 @@ function starknetCallReducer(state: State, action: Action): State {
 
 interface UseStarknetCallOptions {
   watch?: boolean
+  blockNumber?: BlockNumber
 }
 
 interface UseStarknetCallArgs<T extends unknown[]> {
@@ -86,10 +87,11 @@ export function useStarknetCall<T extends unknown[]>({
 
   // default to true
   const watch = options?.watch !== undefined ? options.watch : true
+  const blockNumber = options?.blockNumber || 'pending'
 
   const callContract = useCallback(async () => {
     if (contract && method && args) {
-      return await contract.call(method, args)
+      return await contract.call(method, args, { blockIdentifier: blockNumber })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [contract, method, JSON.stringify(args)])

--- a/packages/core/src/hooks/call.ts
+++ b/packages/core/src/hooks/call.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useReducer } from 'react'
-import { ContractInterface, BlockNumber } from 'starknet'
+import { ContractInterface } from 'starknet'
+import { BlockIdentifier } from 'starknet/dist/provider/utils'
 import { useStarknetBlock } from '../providers/block'
 
 interface State {
@@ -54,7 +55,7 @@ function starknetCallReducer(state: State, action: Action): State {
 
 interface UseStarknetCallOptions {
   watch?: boolean
-  blockNumber?: BlockNumber
+  blockIdentifier?: BlockIdentifier
 }
 
 interface UseStarknetCallArgs<T extends unknown[]> {
@@ -87,11 +88,11 @@ export function useStarknetCall<T extends unknown[]>({
 
   // default to true
   const watch = options?.watch !== undefined ? options.watch : true
-  const blockNumber = options?.blockNumber || 'pending'
+  const blockIdentifier = options?.blockIdentifier || 'pending'
 
   const callContract = useCallback(async () => {
     if (contract && method && args) {
-      return await contract.call(method, args, { blockIdentifier: blockNumber })
+      return await contract.call(method, args, { blockIdentifier })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [contract, method, JSON.stringify(args)])

--- a/website/docs/hooks/call.md
+++ b/website/docs/hooks/call.md
@@ -20,13 +20,15 @@ const { data, loading, error, refresh } = useStarknetCall({ contract, method, ar
   method?: string
   args?: T
   options?: {
-    watch?: boolean
+    watch?: boolean,
+    blockIdentifier?: BlockIdentifier
   }
 }
 ```
 
 If `options.watch` (default: `true`) is set to `false`, the hook will fetch the
 contract value only once.
+If `options.blockIdentifier` (default: `pending`) is set, it is passed to the feeder gateway in the `call_contract` method.
 
 ## Return Values
 


### PR DESCRIPTION
By default, starknet.js queries `pending` state of the blockchain (see https://docs.starknet.io/docs/Blocks/transaction-life-cycle/#the-pending-block).
It can be useful to query the `latest` state of the blockchain or even pass a block number, which the starknet.js lib supports.