### PR TITLE
chore: update starknet.js to ^4.9

### DIFF
--- a/.changeset/neat-games-reply.md
+++ b/.changeset/neat-games-reply.md
@@ -1,0 +1,5 @@
+---
+'@starknet-react/core': patch
+---
+
+update starknet.js to 4.9.0

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "pretty-quick": "^3.1.3",
     "react": "^18.0",
     "react-dom": "^18.0",
-    "starknet": "^4.0",
+    "starknet": "^4.9",
     "turbo": "^1.2.16",
     "typescript": "^4.7.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ importers:
       pretty-quick: ^3.1.3
       react: ^18.0
       react-dom: ^18.0
-      starknet: ^4.0
+      starknet: ^4.9
       turbo: ^1.2.16
       typescript: ^4.7.3
     devDependencies:
@@ -49,7 +49,7 @@ importers:
       pretty-quick: 3.1.3_prettier@2.6.2
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
-      starknet: 4.4.2
+      starknet: 4.9.0
       turbo: 1.2.16
       typescript: 4.7.3
 
@@ -6164,8 +6164,8 @@ packages:
       }
     engines: { node: '>=10' }
     dependencies:
-      is-text-path: 1.0.1
       JSONStream: 1.3.5
+      is-text-path: 1.0.1
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -11907,10 +11907,10 @@ packages:
       escape-string-regexp: 2.0.0
     dev: true
 
-  /starknet/4.4.2:
+  /starknet/4.9.0:
     resolution:
       {
-        integrity: sha512-tSQNwsx0+27pf2oi1fc1bgGDQO7cHFTWBIm+HLT6yAGs53Y/YRrc6jaxbcEl/826gv36ck53pqmF+85t1ILNMg==,
+        integrity: sha512-0Y9Nce0msMs1k3jid93ZuPD2e3yW42FUuMFChRTaq1qcjP8G/fL+5+/zuq441VQ82/JxAHnVqBMvpmMgn5yJSA==,
       }
     dependencies:
       '@ethersproject/bytes': 5.6.1


### PR DESCRIPTION
quite a few changes in the newest revisions of starknet.js (primarily account api's from 0.10.x)