### PR TITLE
Include src folder in package

### DIFF
--- a/.changeset/smart-spies-sell.md
+++ b/.changeset/smart-spies-sell.md
@@ -1,0 +1,5 @@
+---
+'@starknet-react/core': patch
+---
+
+Include src folder in package

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,7 @@
   "types": "dist/index.d.ts",
   "files": [
     "dist",
+    "src",
     "README.md"
   ],
   "scripts": {


### PR DESCRIPTION
When using with a js library, it will try to look for sources in the `src` folder which, at the moment, is not packaged.
