### PR TITLE
fix: support starknet.js `v4.15.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "pretty-quick": "^3.1.3",
     "react": "^18.0",
     "react-dom": "^18.0",
-    "starknet": "^4.14.0",
+    "starknet": "4.15.0",
     "turbo": "^1.2.16",
     "typescript": "^4.7.3"
   },

--- a/packages/core/test/devnet.ts
+++ b/packages/core/test/devnet.ts
@@ -24,8 +24,8 @@ export const DEVNET_ACCOUNTS = [
 
 export const devnetProvider = new SequencerProvider({ baseUrl: DEVNET_URL })
 const originalWaitForTransaction = devnetProvider.waitForTransaction.bind(devnetProvider)
-devnetProvider.waitForTransaction = (txHash, successStates, retryInterval) => {
-  return originalWaitForTransaction(txHash, successStates, retryInterval || 1000)
+devnetProvider.waitForTransaction = (txHash, retryInterval, successStates) => {
+  return originalWaitForTransaction(txHash, retryInterval || 1000, successStates)
 }
 
 export const invalidProvider = new SequencerProvider({ baseUrl: 'http://localhost:100' })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ importers:
       pretty-quick: ^3.1.3
       react: ^18.0
       react-dom: ^18.0
-      starknet: ^4.14.0
+      starknet: 4.15.0
       turbo: ^1.2.16
       typescript: ^4.7.3
     devDependencies:
@@ -49,7 +49,7 @@ importers:
       pretty-quick: 3.1.3_prettier@2.6.2
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
-      starknet: 4.14.0
+      starknet: 4.15.0
       turbo: 1.2.16
       typescript: 4.7.3
 
@@ -11907,10 +11907,10 @@ packages:
       escape-string-regexp: 2.0.0
     dev: true
 
-  /starknet/4.14.0:
+  /starknet/4.15.0:
     resolution:
       {
-        integrity: sha512-3yy4Xd8T4XNjP5VoG+f+GJKv2vdmczX8HBIBKeRm3+p5lJkusYvmaBFwpG6KH6ePLW+/n+OdJSTAa7Ld1a4HdQ==,
+        integrity: sha512-L5gieXVYVn9g7Dg2e6Ux7edD/odvWpq10MZdA8ix3Bq7jGZe+llsreYC10wOIWQYY5AwF5g4r7XplHh0WCHCHQ==,
       }
     dependencies:
       '@ethersproject/bytes': 5.6.1
@@ -11922,7 +11922,7 @@ packages:
       json-bigint: 1.0.0
       minimalistic-assert: 1.0.1
       pako: 2.0.4
-      ts-custom-error: 3.2.2
+      ts-custom-error: 3.3.1
       url-join: 4.0.1
     transitivePeerDependencies:
       - encoding
@@ -12366,10 +12366,10 @@ packages:
       }
     dev: false
 
-  /ts-custom-error/3.2.2:
+  /ts-custom-error/3.3.1:
     resolution:
       {
-        integrity: sha512-u0YCNf2lf6T/vHm+POKZK1yFKWpSpJitcUN3HxqyEcFuNnHIDbyuIQC7QDy/PsBX3giFyk9rt6BFqBAh2lsDZQ==,
+        integrity: sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==,
       }
     engines: { node: '>=14.0.0' }
     dev: true


### PR DESCRIPTION
Closes https://github.com/apibara/starknet-react/issues/203

We need to do some changes to support newer `starknet.js` versions. Tests are currently failing, see there https://github.com/apibara/starknet-react/actions/runs/3742966615/jobs/6354784526.

This PR doesn't fix the linked issue but only fixes this commit https://github.com/0xs34n/starknet.js/commit/bb2a8cddc0ca272a3a291668e80c59ff8758e903. If there are plans to support `starknet.js` versions above `v4.15.0` soon then maybe we can keep the issue open