### PR TITLE
fix: fix handle account change with autoConnect

### DIFF
--- a/packages/core/src/providers/starknet.tsx
+++ b/packages/core/src/providers/starknet.tsx
@@ -208,10 +208,7 @@ function useStarknetManager({
           return
         }
 
-        const account = await lastConnectedConnector.connect()
-        dispatch({ type: 'set_account', account: account.address })
-        dispatch({ type: 'set_provider', provider: account })
-        dispatch({ type: 'set_connector', connector: lastConnectedConnector })
+        await connect(lastConnectedConnector)
       } catch {
         // no-op
       }


### PR DESCRIPTION
When passing `autoConnect = true` to the `StarknetConfig` component, the starknet manager does not handle account change