### PR TITLE
Feat: match wagmi api in block, call, receipt and contract

### DIFF
--- a/packages/core/src/hooks/account.test.tsx
+++ b/packages/core/src/hooks/account.test.tsx
@@ -7,7 +7,16 @@ import { Connector } from '~/connectors'
 
 function useTestHook() {
   const { connectors, connect } = useStarknet()
-  const { account, address, connector, status } = useAccount()
+  const {
+    account,
+    address,
+    connector,
+    status,
+    isConnected,
+    isConnecting,
+    isReconnecting,
+    isDisconnected,
+  } = useAccount()
   return {
     account,
     connectors,
@@ -15,6 +24,10 @@ function useTestHook() {
     address,
     connector,
     status,
+    isConnected,
+    isConnecting,
+    isReconnecting,
+    isDisconnected,
   }
 }
 
@@ -54,6 +67,10 @@ describe('useAccount', () => {
         expect(result.current.address).toBeUndefined()
         expect(result.current.connector).toBeUndefined()
         expect(result.current.status).toEqual('disconnected')
+        expect(result.current.isConnected).toBeFalsy()
+        expect(result.current.isConnecting).toBeFalsy()
+        expect(result.current.isReconnecting).toBeFalsy()
+        expect(result.current.isDisconnected).toBeTruthy()
       })
     })
   })
@@ -97,6 +114,8 @@ describe('useAccount', () => {
         expect(result.current.address).toEqual(deventAccounts[2].address)
         expect(result.current.connector).toBeDefined()
         expect(result.current.status).toEqual('connected')
+        expect(result.current.isConnected).toBeTruthy()
+        expect(result.current.isDisconnected).toBeFalsy()
       })
     })
   })

--- a/packages/core/src/hooks/account.test.tsx
+++ b/packages/core/src/hooks/account.test.tsx
@@ -7,16 +7,7 @@ import { Connector } from '~/connectors'
 
 function useTestHook() {
   const { connectors, connect } = useStarknet()
-  const {
-    account,
-    address,
-    connector,
-    status,
-    isConnected,
-    isConnecting,
-    isReconnecting,
-    isDisconnected,
-  } = useAccount()
+  const { account, address, connector, status } = useAccount()
   return {
     account,
     connectors,
@@ -24,10 +15,6 @@ function useTestHook() {
     address,
     connector,
     status,
-    isConnected,
-    isConnecting,
-    isReconnecting,
-    isDisconnected,
   }
 }
 
@@ -67,10 +54,6 @@ describe('useAccount', () => {
         expect(result.current.address).toBeUndefined()
         expect(result.current.connector).toBeUndefined()
         expect(result.current.status).toEqual('disconnected')
-        expect(result.current.isConnected).toBeFalsy()
-        expect(result.current.isConnecting).toBeFalsy()
-        expect(result.current.isReconnecting).toBeFalsy()
-        expect(result.current.isDisconnected).toBeTruthy()
       })
     })
   })
@@ -114,8 +97,6 @@ describe('useAccount', () => {
         expect(result.current.address).toEqual(deventAccounts[2].address)
         expect(result.current.connector).toBeDefined()
         expect(result.current.status).toEqual('connected')
-        expect(result.current.isConnected).toBeTruthy()
-        expect(result.current.isDisconnected).toBeFalsy()
       })
     })
   })

--- a/packages/core/src/hooks/account.ts
+++ b/packages/core/src/hooks/account.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { AccountInterface } from 'starknet'
 import { Connector } from '../connectors'
-import { useConnect } from './connectors'
+import { useConnectors } from './connectors'
 import { useStarknet } from '../providers'
 
 /** Account connection status. */
@@ -47,7 +47,7 @@ export interface UseAccountResult {
  */
 export function useAccount(): UseAccountResult {
   const { account: connectedAccount } = useStarknet()
-  const { connectors } = useConnect()
+  const { connectors } = useConnectors()
   const [state, setState] = useState<UseAccountResult>({ status: 'disconnected' })
 
   const refreshState = useCallback(async () => {

--- a/packages/core/src/hooks/block.test.tsx
+++ b/packages/core/src/hooks/block.test.tsx
@@ -1,4 +1,4 @@
-import { useBlock } from './block'
+import { useBlock, useBlockNumber } from './block'
 import { renderHook, waitFor } from '../../test/react'
 import { connectors, devnetProvider, compiledErc20 } from '../../test/devnet'
 
@@ -15,6 +15,7 @@ describe('useBlock', () => {
     await waitFor(
       () => {
         expect(result.current.data).toBeDefined()
+        expect(result.current.status).toEqual('success')
       },
       {
         timeout: 30000,
@@ -29,6 +30,29 @@ describe('useBlock', () => {
     await waitFor(
       () => {
         expect(result.current.isError).toBeTruthy()
+      },
+      {
+        timeout: 30000,
+        interval: 1000,
+      }
+    )
+  })
+})
+
+describe('useBlockNumber', () => {
+  beforeAll(async () => {
+    await devnetProvider.deployContract({
+      contract: compiledErc20,
+    })
+  })
+
+  it('returns the current block', async () => {
+    const { result } = renderHook(() => useBlockNumber(), { connectors })
+
+    await waitFor(
+      () => {
+        expect(result.current.blockNumber).toBeDefined()
+        expect(result.current.status).toEqual('success')
       },
       {
         timeout: 30000,

--- a/packages/core/src/hooks/call.test.tsx
+++ b/packages/core/src/hooks/call.test.tsx
@@ -10,8 +10,8 @@ describe('useStarknetCall', () => {
   })
 
   function useTestHook({
-    address,
-    functionName,
+    address = '',
+    functionName = '',
     args,
   }: {
     address?: string

--- a/packages/core/src/hooks/call.test.tsx
+++ b/packages/core/src/hooks/call.test.tsx
@@ -1,7 +1,6 @@
 import { renderHook, waitFor } from '../../test/react'
 import { compiledErc20, devnetProvider } from '../../test/devnet'
-import { useStarknetCall } from './call'
-import { useContract } from './contract'
+import { useContractRead } from './call'
 
 describe('useStarknetCall', () => {
   let address: string
@@ -12,33 +11,41 @@ describe('useStarknetCall', () => {
 
   function useTestHook({
     address,
-    method,
+    functionName,
     args,
   }: {
     address?: string
-    method?: string
+    functionName?: string
     args?: unknown[]
   }) {
-    const { contract } = useContract({ abi: compiledErc20.abi, address })
-    return useStarknetCall({
-      contract,
-      method,
+    return useContractRead({
+      abi: compiledErc20.abi,
+      address,
+      functionName,
       args,
-      options: {
-        watch: false,
-      },
+      watch: false,
     })
   }
 
   describe('when reading', () => {
     it('returns an error if the read fails', async () => {
-      const { result } = renderHook(() => useTestHook({ method: 'balance_of', address, args: [] }))
+      const { result } = renderHook(() =>
+        useTestHook({ functionName: 'balance_of', address, args: [] })
+      )
 
       await waitFor(
         () => {
           expect(result.current.data).toBeUndefined()
           expect(result.current.error).toBeDefined()
-          expect(result.current.loading).toBeFalsy()
+          expect(result.current.isIdle).toBeTruthy()
+          expect(result.current.isLoading).toBeFalsy()
+          expect(result.current.isFetching).toBeFalsy()
+          expect(result.current.isSuccess).toBeFalsy()
+          expect(result.current.isError).toBeTruthy()
+          expect(result.current.isFetched).toBeTruthy()
+          expect(result.current.isFetchedAfterMount).toBeTruthy()
+          expect(result.current.isRefetching).toBeFalsy()
+          expect(result.current.status).toEqual('error')
         },
         {
           timeout: 30000,
@@ -49,14 +56,22 @@ describe('useStarknetCall', () => {
 
     it('returns data if the read succeed', async () => {
       const { result } = renderHook(() =>
-        useTestHook({ method: 'get_total_supply', address, args: [] })
+        useTestHook({ functionName: 'get_total_supply', address, args: [] })
       )
 
       await waitFor(
         () => {
           expect(result.current.data).toBeDefined()
           expect(result.current.error).toBeUndefined()
-          expect(result.current.loading).toBeFalsy()
+          expect(result.current.isIdle).toBeTruthy()
+          expect(result.current.isLoading).toBeFalsy()
+          expect(result.current.isFetching).toBeFalsy()
+          expect(result.current.isSuccess).toBeTruthy()
+          expect(result.current.isError).toBeFalsy()
+          expect(result.current.isFetched).toBeTruthy()
+          expect(result.current.isFetchedAfterMount).toBeTruthy()
+          expect(result.current.isRefetching).toBeFalsy()
+          expect(result.current.status).toEqual('success')
         },
         {
           timeout: 30000,
@@ -68,12 +83,22 @@ describe('useStarknetCall', () => {
 
   describe('when contract is undefined', () => {
     it('returns no data', async () => {
-      const { result } = renderHook(() => useTestHook({ method: 'get_total_supply', args: [] }))
+      const { result } = renderHook(() =>
+        useTestHook({ functionName: 'get_total_supply', args: [] })
+      )
 
       await waitFor(() => {
         expect(result.current.data).toBeUndefined()
         expect(result.current.error).toBeUndefined()
-        expect(result.current.loading).toBeTruthy()
+        expect(result.current.isIdle).toBeTruthy()
+        expect(result.current.isLoading).toBeTruthy()
+        expect(result.current.isFetching).toBeTruthy()
+        expect(result.current.isSuccess).toBeFalsy()
+        expect(result.current.isError).toBeFalsy()
+        expect(result.current.isFetched).toBeFalsy()
+        expect(result.current.isFetchedAfterMount).toBeFalsy()
+        expect(result.current.isRefetching).toBeFalsy()
+        expect(result.current.status).toEqual('loading')
       })
     })
   })
@@ -85,19 +110,37 @@ describe('useStarknetCall', () => {
       await waitFor(() => {
         expect(result.current.data).toBeUndefined()
         expect(result.current.error).toBeUndefined()
-        expect(result.current.loading).toBeTruthy()
+        expect(result.current.isIdle).toBeTruthy()
+        expect(result.current.isLoading).toBeTruthy()
+        expect(result.current.isFetching).toBeTruthy()
+        expect(result.current.isSuccess).toBeFalsy()
+        expect(result.current.isError).toBeFalsy()
+        expect(result.current.isFetched).toBeFalsy()
+        expect(result.current.isFetchedAfterMount).toBeFalsy()
+        expect(result.current.isRefetching).toBeFalsy()
+        expect(result.current.status).toEqual('loading')
       })
     })
   })
 
   describe('when args is undefined', () => {
     it('returns no data', async () => {
-      const { result } = renderHook(() => useTestHook({ method: 'get_total_supply', address }))
+      const { result } = renderHook(() =>
+        useTestHook({ functionName: 'get_total_supply', address })
+      )
 
       await waitFor(() => {
         expect(result.current.data).toBeUndefined()
         expect(result.current.error).toBeUndefined()
-        expect(result.current.loading).toBeTruthy()
+        expect(result.current.isIdle).toBeTruthy()
+        expect(result.current.isLoading).toBeTruthy()
+        expect(result.current.isFetching).toBeTruthy()
+        expect(result.current.isSuccess).toBeFalsy()
+        expect(result.current.isError).toBeFalsy()
+        expect(result.current.isFetched).toBeFalsy()
+        expect(result.current.isFetchedAfterMount).toBeFalsy()
+        expect(result.current.isRefetching).toBeFalsy()
+        expect(result.current.status).toEqual('loading')
       })
     })
   })

--- a/packages/core/src/hooks/call.ts
+++ b/packages/core/src/hooks/call.ts
@@ -18,11 +18,11 @@ export interface UseContractReadOptions {
 /** Arguments for `useContractRead`. */
 export interface UseContractReadArgs<T extends unknown[]> {
   /** The target contract's ABI. */
-  abi?: Abi
+  abi: Abi
   /** The target contract's address. */
-  address?: string
+  address: string
   /** The contract's function name. */
-  functionName?: string
+  functionName: string
   /** Read arguments. */
   args?: T
 }

--- a/packages/core/src/hooks/execute.test.tsx
+++ b/packages/core/src/hooks/execute.test.tsx
@@ -1,10 +1,10 @@
 import { renderHook, waitFor, act } from '../../test/react'
 import { compiledDapp, devnetProvider, connectors } from '../../test/devnet'
-import { Call, useStarknetExecute } from './execute'
+import { Call, useContractWrite } from './execute'
 import { useStarknet } from '~/providers'
 import { useAccount } from './account'
 
-describe('useStarknetExecute', () => {
+describe('useContractWrite', () => {
   let address: string
   let calls: Call[]
   beforeAll(async () => {
@@ -28,16 +28,18 @@ describe('useStarknetExecute', () => {
   function useTestHook({ calls }: { calls?: Call[] }) {
     const { connectors, connect } = useStarknet()
     const { account } = useAccount()
-    const { data, error, loading, reset, execute } = useStarknetExecute({ calls })
+    const test = useContractWrite({ calls })
+    console.log(test)
+    const { data, error, isLoading, reset, write } = useContractWrite({ calls })
     return {
       account,
       connectors,
       connect,
       data,
       error,
-      loading,
+      isLoading,
       reset,
-      execute,
+      write,
     }
   }
 
@@ -52,7 +54,7 @@ describe('useStarknetExecute', () => {
 
       await act(async () => {
         try {
-          await result.current.execute()
+          await result.current.write()
         } catch (err) {
           // error is expected
           console.log(err)
@@ -89,7 +91,7 @@ describe('useStarknetExecute', () => {
       })
 
       await act(async () => {
-        await result.current.execute()
+        await result.current.write()
       })
 
       await waitFor(() => {

--- a/packages/core/src/hooks/receipt.test.tsx
+++ b/packages/core/src/hooks/receipt.test.tsx
@@ -1,8 +1,8 @@
 import { renderHook, waitFor } from '../../test/react'
 import { compiledErc20, devnetProvider } from '../../test/devnet'
-import { useTransactionReceipt } from './receipt'
+import { useWaitForTransaction } from './receipt'
 
-describe('useTransactionReceipt', () => {
+describe('useWaitForTransaction', () => {
   let hash: string
   beforeAll(async () => {
     const tx = await devnetProvider.deployContract({ contract: compiledErc20 })
@@ -11,12 +11,12 @@ describe('useTransactionReceipt', () => {
 
   describe('when given a valid tx hash', () => {
     it('returns the transaction receipt', async () => {
-      const { result } = renderHook(() => useTransactionReceipt({ hash }))
+      const { result } = renderHook(() => useWaitForTransaction({ hash }))
 
       await waitFor(
         () => {
           expect(result.current.error).toBeUndefined()
-          expect(result.current.loading).toBeFalsy()
+          expect(result.current.isLoading).toBeFalsy()
           expect(result.current.data?.transaction_hash).toEqual(hash)
         },
         {
@@ -28,13 +28,13 @@ describe('useTransactionReceipt', () => {
 
     it('refreshes data on hash change', async () => {
       const { result, rerender } = renderHook(({ hash }: { hash?: string } = { hash: undefined }) =>
-        useTransactionReceipt({ hash })
+        useWaitForTransaction({ hash })
       )
 
       await waitFor(
         () => {
           expect(result.current.error).toBeUndefined()
-          expect(result.current.loading).toBeTruthy()
+          expect(result.current.isLoading).toBeTruthy()
           expect(result.current.data).toBeUndefined()
         },
         {
@@ -48,7 +48,7 @@ describe('useTransactionReceipt', () => {
       await waitFor(
         () => {
           expect(result.current.error).toBeUndefined()
-          expect(result.current.loading).toBeFalsy()
+          expect(result.current.isLoading).toBeFalsy()
           expect(result.current.data?.transaction_hash).toEqual(hash)
         },
         {

--- a/packages/core/src/hooks/transaction.test.tsx
+++ b/packages/core/src/hooks/transaction.test.tsx
@@ -15,9 +15,15 @@ describe('useTransaction', () => {
 
       await waitFor(
         () => {
-          expect(result.current.error).toBeUndefined()
-          expect(result.current.loading).toBeFalsy()
           expect(result.current.data?.transaction_hash).toEqual(hash)
+          expect(result.current.error).toBeUndefined()
+          expect(result.current.isIdle).toBeTruthy()
+          expect(result.current.isLoading).toBeFalsy()
+          expect(result.current.isFetching).toBeFalsy()
+          expect(result.current.isFetched).toBeTruthy()
+          expect(result.current.isFetchedAfterMount).toBeTruthy()
+          expect(result.current.isRefetching).toBeFalsy()
+          expect(result.current.status).toEqual('success')
         },
         {
           timeout: 10000,
@@ -34,8 +40,16 @@ describe('useTransaction', () => {
       await waitFor(
         () => {
           expect(result.current.error).toBeDefined()
-          expect(result.current.loading).toBeFalsy()
           expect(result.current.data).toBeUndefined()
+          expect(result.current.isLoading).toBeFalsy()
+          expect(result.current.isIdle).toBeTruthy()
+          expect(result.current.isFetching).toBeFalsy()
+          expect(result.current.isSuccess).toBeFalsy()
+          expect(result.current.isError).toBeTruthy()
+          expect(result.current.isFetched).toBeTruthy()
+          expect(result.current.isFetchedAfterMount).toBeTruthy()
+          expect(result.current.isRefetching).toBeFalsy()
+          expect(result.current.status).toEqual('error')
         },
         {
           timeout: 10000,
@@ -47,9 +61,18 @@ describe('useTransaction', () => {
 
       await waitFor(
         () => {
-          expect(result.current.error).toBeUndefined()
-          expect(result.current.loading).toBeFalsy()
           expect(result.current.data?.transaction_hash).toEqual(hash)
+          expect(result.current.error).toBeUndefined()
+          expect(result.current.isLoading).toBeFalsy()
+          expect(result.current.isIdle).toBeTruthy()
+          expect(result.current.isLoading).toBeFalsy()
+          expect(result.current.isFetching).toBeFalsy()
+          expect(result.current.isSuccess).toBeTruthy()
+          expect(result.current.isError).toBeFalsy()
+          expect(result.current.isFetched).toBeTruthy()
+          expect(result.current.isFetchedAfterMount).toBeTruthy()
+          expect(result.current.isRefetching).toBeFalsy()
+          expect(result.current.status).toEqual('success')
         },
         {
           timeout: 10000,
@@ -107,9 +130,9 @@ describe('useTransactions', () => {
       await waitFor(
         () => {
           expect(result.current.length).toEqual(3)
-          expect(result.current[0].loading).toBeFalsy()
-          expect(result.current[1].loading).toBeFalsy()
-          expect(result.current[2].loading).toBeFalsy()
+          expect(result.current[0].isLoading).toBeFalsy()
+          expect(result.current[1].isLoading).toBeFalsy()
+          expect(result.current[2].isLoading).toBeFalsy()
 
           expect(result.current[0].data?.transaction_hash).toEqual(hash0)
           expect(result.current[1].error).toBeDefined()


### PR DESCRIPTION
Refactoring to match wagmi's api : #105 
- Add `useBlockNumber` and refactor `useBlock`
- Refactor `useStarknetCall` to `useContractRead`
- Refactor `useTransaction` and `useTransactions`
- Refactor `useTransactionReceipt` to `useWaitForTransaction`
- Refactor `useAccount`
- Refactor `useStarknetExecute` to `useContractWrite`

Already matching wagmi's api : 
- `useNetwork`