### PR TITLE
fix: overflow on Markdown component

### DIFF
--- a/website/components/CodeBlock/index.tsx
+++ b/website/components/CodeBlock/index.tsx
@@ -24,7 +24,7 @@ export function CodeBlock({
   }
 
   return (
-    <Box p="5" rounded="md" my="2" bg="cat.mantle">
+    <Box p="5" rounded="md" my="2" bg="cat.mantle" overflowX="scroll">
       <Highlight {...defaultProps} code={code} language={language as Language} theme={theme}>
         {({ className, style, tokens, getLineProps, getTokenProps }) => (
           <pre className={className} style={style}>


### PR DESCRIPTION
## Before

https://user-images.githubusercontent.com/37301269/223188252-bccaa33f-e72d-4df5-9413-829fd181bdf8.mov

## After


https://user-images.githubusercontent.com/37301269/223188412-e58489aa-7951-4943-9947-1d77db018ddd.mov

