### PR TITLE
feat(create-starknet): identify which package mangager is used and add option to select it manually

### DIFF
--- a/.changeset/curvy-games-sneeze.md
+++ b/.changeset/curvy-games-sneeze.md
@@ -1,0 +1,5 @@
+---
+'create-starknet': minor
+---
+
+Added option to select the package manager the new project will be created with

--- a/packages/create-starknet/README.md
+++ b/packages/create-starknet/README.md
@@ -25,5 +25,8 @@ create-starknet [project-directory] [options]
 Options:
   -V, --version  output the version number
   -t, --template <name>  Explicitly tell the CLI to bootstrap the app using the specified template (choices: "next", "vite")
+  --use-npm              Explicitly tell the CLI to bootstrap the app using npm
+  --use-yarn             Explicitly tell the CLI to bootstrap the app using yarn
+  --use-pnpm             Explicitly tell the CLI to bootstrap the app using pnpm
   -h, --help     display help for command
 ```

--- a/packages/create-starknet/helpers/packageManager.ts
+++ b/packages/create-starknet/helpers/packageManager.ts
@@ -1,0 +1,17 @@
+export type PackageManager = 'npm' | 'yarn' | 'pnpm'
+
+export function getPackageManager(): PackageManager {
+  const userAgent = process.env.npm_config_user_agent
+
+  if (userAgent) {
+    if (userAgent.includes('yarn')) {
+      return 'yarn'
+    } else if (userAgent.includes('pnpm')) {
+      return 'pnpm'
+    } else {
+      return 'npm'
+    }
+  } else {
+    return 'npm'
+  }
+}


### PR DESCRIPTION
<img width="666" alt="Screenshot 2023-04-12 at 03 26 36" src="https://user-images.githubusercontent.com/37301269/231323522-e8a8a871-3777-4264-9a62-622ff8ed44bd.png">

- Identified which package manager is used thanks to the npm user agent.
- Added option to select the package manager with non-interactive mode
- Updated `README.md`

This change will be used when installing automatically packages when initializing a project (in a next PR)
The next PR will update the documentation website