### PR TITLE
chore: fix change account

### DIFF
--- a/.changeset/beige-pans-run.md
+++ b/.changeset/beige-pans-run.md
@@ -1,0 +1,5 @@
+---
+'@starknet-react/core': minor
+---
+
+fix change account


### PR DESCRIPTION
This commit fixes the `handleAccountChanged` function. Previously, when changing accounts in the wallet, starknet-react would not prompt the wallet to approve connecting to the dApp with the new account.

As a side effect, we now detect and handle network changes. 🎉 

Notes:
- `handleAccountChanged` now simply calls the disconnect and connect functions. `connector.initEventListener(handleAccountChanged)` needed to be called after setting `state.connector`. This is why it is now called in a useEffect.
- In the `disconnect` function, some logic has been moved to execute before `state.connector.disconnect()`. This allows for the correct handling of cases where the user changes accounts but rejects approval to connect to the dApp with the new account.