### PR TITLE
Feat: Add a useBalance hook for ERC20s

### DIFF
--- a/.changeset/fast-maps-peel.md
+++ b/.changeset/fast-maps-peel.md
@@ -1,0 +1,5 @@
+---
+'@starknet-react/core': patch
+---
+
+add useBalance hook

--- a/packages/core/src/connectors/index.ts
+++ b/packages/core/src/connectors/index.ts
@@ -1,8 +1,8 @@
 export { Connector } from './base'
 export {
   InjectedConnector,
-  InjectedConnectorOptions,
-  IStarknetWindowObject,
-  EventHandler,
-  EventType,
+  type InjectedConnectorOptions,
+  type IStarknetWindowObject,
+  type EventHandler,
+  type EventType,
 } from './injected'

--- a/packages/core/src/hooks/balance.test.tsx
+++ b/packages/core/src/hooks/balance.test.tsx
@@ -1,0 +1,76 @@
+import { renderHook, waitFor } from '../../test/react'
+import { compiledErc20, deventAccounts, erc20ClassHash } from '../../test/devnet'
+import { useBalance } from './balance'
+
+describe('useBalance', () => {
+  let address: string
+  beforeAll(async () => {
+    const account = deventAccounts[1]!
+    const tx = await account.declareDeploy({ contract: compiledErc20, classHash: erc20ClassHash })
+    address = tx.deploy.contract_address
+  })
+
+  function useTestHook({ address, token }: { address?: string; token?: string }) {
+    return useBalance({
+      address,
+      token,
+    })
+  }
+
+  describe('when address is undefined', () => {
+    it('returns no data', async () => {
+      const { result } = renderHook(() => useTestHook({ address: '' }))
+      await waitFor(() => {
+        expect(result.current.data).toBeUndefined()
+        expect(result.current.error).toBeUndefined()
+        expect(result.current.isIdle).toBeTruthy()
+        expect(result.current.isLoading).toBeTruthy()
+        expect(result.current.isFetching).toBeFalsy()
+        expect(result.current.isSuccess).toBeFalsy()
+        expect(result.current.isError).toBeFalsy()
+        expect(result.current.isFetched).toBeFalsy()
+        expect(result.current.isFetchedAfterMount).toBeFalsy()
+        expect(result.current.isRefetching).toBeFalsy()
+        expect(result.current.status).toEqual('loading')
+      })
+    })
+  })
+
+  describe('when reading', () => {
+    it('returns data if it succeeds', async () => {
+      const { result } = renderHook(() => useTestHook({ address }))
+
+      await waitFor(() => {
+        expect(result.current.data).toBeDefined()
+        expect(result.current.error).toBeUndefined()
+        expect(result.current.isIdle).toBeTruthy()
+        expect(result.current.isLoading).toBeFalsy()
+        expect(result.current.isFetching).toBeFalsy()
+        expect(result.current.isSuccess).toBeTruthy()
+        expect(result.current.isError).toBeFalsy()
+        expect(result.current.isFetched).toBeTruthy()
+        expect(result.current.isFetchedAfterMount).toBeTruthy()
+        expect(result.current.isRefetching).toBeFalsy()
+        expect(result.current.status).toEqual('success')
+      })
+    })
+
+    it('formats balance correctly', async () => {
+      const devnetETHTokenAddress =
+        '0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7'
+      const defaultAccountBalanceWei = 1000000000000000000000
+      const balanceInEther = defaultAccountBalanceWei / 10 ** 18
+
+      const { result } = renderHook(() =>
+        useTestHook({
+          address: deventAccounts[0].address,
+          token: devnetETHTokenAddress,
+        })
+      )
+
+      await waitFor(() => {
+        expect(result.current.data?.formatted).toBe(balanceInEther.toString())
+      })
+    })
+  })
+})

--- a/packages/core/src/hooks/balance.test.tsx
+++ b/packages/core/src/hooks/balance.test.tsx
@@ -1,15 +1,8 @@
 import { renderHook, waitFor } from '../../test/react'
-import { compiledErc20, deventAccounts, erc20ClassHash } from '../../test/devnet'
+import { deventAccounts } from '../../test/devnet'
 import { useBalance } from './balance'
 
 describe('useBalance', () => {
-  let address: string
-  beforeAll(async () => {
-    const account = deventAccounts[1]!
-    const tx = await account.declareDeploy({ contract: compiledErc20, classHash: erc20ClassHash })
-    address = tx.deploy.contract_address
-  })
-
   function useTestHook({ address, token }: { address?: string; token?: string }) {
     return useBalance({
       address,
@@ -38,7 +31,7 @@ describe('useBalance', () => {
 
   describe('when reading', () => {
     it('returns data if it succeeds', async () => {
-      const { result } = renderHook(() => useTestHook({ address }))
+      const { result } = renderHook(() => useTestHook({ address: deventAccounts[1].address }))
 
       await waitFor(() => {
         expect(result.current.data).toBeDefined()

--- a/packages/core/src/hooks/balance.ts
+++ b/packages/core/src/hooks/balance.ts
@@ -165,21 +165,18 @@ export function useBalance({
     }
 
     const {
-      decimals: { decimals },
+      decimals: { decimals: contractDecimals },
       balance: { balance: balanceUint256 },
       symbol: { symbol },
     } = contractData
 
-    const contractDecimals = decimals.toNumber()
+    const decimals = contractDecimals.toNumber()
     const balanceAsBN = uint256.uint256ToBN(balanceUint256)
-    const formatted = (
-      Number(balanceAsBN.toString()) /
-      10 ** (formatUnits || contractDecimals)
-    ).toString()
+    const formatted = (Number(balanceAsBN.toString()) / 10 ** (formatUnits || decimals)).toString()
     const formattedSymbol = shortString.decodeShortString(symbol)
 
     return {
-      decimals: contractDecimals,
+      decimals,
       formatted,
       symbol: formattedSymbol,
       value: balanceAsBN,

--- a/packages/core/src/hooks/balance.ts
+++ b/packages/core/src/hooks/balance.ts
@@ -1,0 +1,189 @@
+import {
+  BlockNumber,
+  ContractInterface,
+  ProviderInterface,
+  Result,
+  shortString,
+  uint256,
+} from 'starknet'
+import { UseContractReadOptions, UseContractReadResult } from './call'
+import { useContract, useStarknet } from '..'
+import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useInvalidateOnBlock } from './invalidate'
+
+/** Arguments for `useBalance`. */
+export interface UseBalanceArgs extends UseContractReadOptions {
+  /** The target contract's address. */
+  token?: string
+  /** The target address. */
+  address?: string
+  /** Decimals. */
+  decimals?: number
+}
+
+export interface UseBalanceReadResult extends Omit<UseContractReadResult, 'data'> {
+  data?: {
+    decimals: number
+    formatted: string
+    symbol: string
+    value: bigint
+  }
+}
+
+const ETH_TOKEN_ADDRESS = '0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7'
+const BALANCE_ABI_FRAGMENT = [
+  {
+    name: 'balanceOf',
+    type: 'function',
+    inputs: [
+      {
+        name: 'account',
+        type: 'felt',
+      },
+    ],
+    outputs: [
+      {
+        name: 'balance',
+        type: 'Uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    inputs: [],
+    name: 'symbol',
+    outputs: [
+      {
+        name: 'symbol',
+        type: 'felt',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'decimals',
+    outputs: [
+      {
+        name: 'decimals',
+        type: 'felt',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+]
+
+export function useBalance({
+  token = ETH_TOKEN_ADDRESS,
+  address,
+  decimals,
+  watch = false,
+  blockIdentifier = 'pending',
+}: UseBalanceArgs): UseBalanceReadResult {
+  const { library } = useStarknet()
+  const { contract } = useContract({ abi: BALANCE_ABI_FRAGMENT, address: token })
+
+  const queryKey_ = useMemo(
+    () => queryKey({ library, args: { contract, args: [address], blockIdentifier } }),
+    [library, contract, address, blockIdentifier]
+  )
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const {
+    data: contractData,
+    error,
+    isStale: isIdle,
+    isLoading,
+    isFetching,
+    isSuccess,
+    isError,
+    isFetched,
+    isFetchedAfterMount,
+    isRefetching,
+    refetch,
+    status,
+  } = useQuery<ReadContractResult | undefined>(
+    queryKey_,
+    readContract({ args: { contract, args: [address], blockIdentifier } }),
+    {
+      enabled: !!address,
+    }
+  )
+
+  useInvalidateOnBlock({ enabled: watch, queryKey: queryKey_ })
+
+  const data = useMemo<UseBalanceReadResult['data']>(() => {
+    if (!contractData) {
+      return undefined
+    }
+
+    const contractDecimals = Number(BigInt(contractData.decimals.decimals).toString())
+    const balance = Number(BigInt(contractData.balance.balance).toString())
+    const formatted = (balance / 10 ** (decimals || contractDecimals)).toString()
+    const formattedSymbol = shortString.decodeShortString(contractData.symbol.symbol)
+
+    return {
+      decimals: decimals || contractDecimals,
+      formatted,
+      symbol: formattedSymbol,
+      value: contractData.balance.balance,
+    }
+  }, [contractData, decimals])
+
+  return {
+    data,
+    error: error ?? undefined,
+    isIdle,
+    isLoading,
+    isFetching,
+    isSuccess,
+    isError,
+    isFetched,
+    isFetchedAfterMount,
+    isRefetching,
+    refetch,
+    status,
+  }
+}
+
+interface ReadContractArgs {
+  contract?: ContractInterface
+  args?: unknown[]
+  blockIdentifier: BlockNumber
+}
+
+type ReadContractResult = {
+  balance: Result
+  symbol: Result
+  decimals: Result
+} | null
+
+function readContract({ args }: { args: ReadContractArgs }) {
+  return async () => {
+    if (!args.args || !args.contract) return null
+
+    const [balance, symbol, decimals] = await Promise.all([
+      args.contract.call('balanceOf', args.args),
+      args.contract.call('symbol', []),
+      args.contract.call('decimals', []),
+    ])
+
+    return { balance, symbol, decimals }
+  }
+}
+
+function queryKey({ library, args }: { library: ProviderInterface; args: ReadContractArgs }) {
+  const { contract, args: callArgs, blockIdentifier } = args
+  return [
+    {
+      entity: 'balance',
+      chainId: library.chainId,
+      contract: contract?.address,
+      args: callArgs,
+      blockIdentifier,
+    },
+  ] as const
+}

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './account'
+export * from './balance'
 export * from './block'
 export * from './call'
 export * from './connectors'


### PR DESCRIPTION
Closes #236 

Add a `useBalance` hook, based on the wagmi equivalent, that fetches balance info for ERC 20 tokens.
```ts
const { data } = useBalance({
  address, // address to fetch balance for
  token, // token address, defaults to ETH token
  formatUnits // defaults to token decimals
})
```
Returns the original balance, formatted balance, symbol, and decimals:
```ts
Balance: {data.formatted} {data.symbol}
```