### PR TITLE
Fix useSignTypedData docs

### DIFF
--- a/packages/core/src/hooks/call.ts
+++ b/packages/core/src/hooks/call.ts
@@ -63,7 +63,7 @@ export interface UseContractReadResult {
  * ```tsx
  * function Component() {
  *   const { address } = useAccount()
- *   const { data, isLoading, error, refetch } = useStarknetCall({
+ *   const { data, isLoading, error, refetch } = useContractRead({
  *     address: ethAddress,
  *     abi: compiledErc20.abi,
  *     functionName: 'balanceOf',
@@ -72,7 +72,7 @@ export interface UseContractReadResult {
  *   })
  *
  *   if (isLoading) return <span>Loading...</span>
- *   if (error) return <span>Error: {error}</span>
+ *   if (error) return <span>Error: {JSON.stringify(error)}</span>
  *
  *   return (
  *     <div>

--- a/packages/core/src/hooks/sign.ts
+++ b/packages/core/src/hooks/sign.ts
@@ -81,12 +81,18 @@ export interface UseSignTypedDataResult {
  * wallet private key.
  *
  * @example
- * This example shows how to sign some data.
+ * This example shows how to sign some data. The message must follow
+ * EIP712 (https://www.starknetjs.com/docs/guides/signature).
+ *
  * ```tsx
  * function Component() {
- *   const { data, signTypedData } = useSignTypedData(message)
  *   const message = {
  *     types: {
+ *      StarkNetDomain: [
+ *         { name: "name", type: "felt" },
+ *         { name: "version", type: "felt" },
+ *         { name: "chainId", type: "felt" },
+ *       ],
  *       Person: [
  *         { name: 'name', type: 'felt' }
  *       ],
@@ -106,6 +112,8 @@ export interface UseSignTypedDataResult {
  *       }
  *     }
  *   }
+ *
+ *  const { data, signTypedData } = useSignTypedData(message)
  *
  *   return (
  *     <>


### PR DESCRIPTION
Why:
  - Currently the code example for `useSignTypedData` is incorrect, so on the docs site it doesn't work.

How: 
  - Add StarkNetDomain types to the signed object
  - Use the hook after the message const is initialized
  - Add info about EIP712