### PR TITLE
feat: add connector icon support

### DIFF
--- a/packages/core/src/connectors/base.ts
+++ b/packages/core/src/connectors/base.ts
@@ -24,4 +24,6 @@ export abstract class Connector<Options = any> {
   abstract id(): string
   /** Connector name */
   abstract name(): string
+  /** Connector icon */
+  abstract icon(): string
 }

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -117,6 +117,14 @@ export class InjectedConnector extends Connector<InjectedConnectorOptions> {
     return this._wallet.name
   }
 
+  icon(): string {
+    this.ensureWallet()
+    if (!this._wallet) {
+      throw new ConnectorNotConnectedError()
+    }
+    return this._wallet.icon
+  }
+
   async initEventListener(accountChangeCb: EventHandler) {
     await this.ensureWallet()
 


### PR DESCRIPTION
Wallet icons can now be accessed with `connector.icon()`. Very useful for dapps to show which wallet is connected