### PR TITLE
Invalidate transaction queries on new block

### DIFF
--- a/.changeset/two-elephants-wonder.md
+++ b/.changeset/two-elephants-wonder.md
@@ -1,0 +1,5 @@
+---
+'@starknet-react/core': patch
+---
+
+Invalidate transaction queries on new block

--- a/packages/core/src/hooks/transaction.ts
+++ b/packages/core/src/hooks/transaction.ts
@@ -116,7 +116,8 @@ export interface UseTransactionsArgs {
  * ```tsx
  * function Component() {
  *   const results = useTransactions({
- *     hashes: [txHash, txHash2]
+ *     hashes: [txHash, txHash2],
+ *     watch: true,
  *   })
  *
  *   return (
@@ -131,7 +132,10 @@ export interface UseTransactionsArgs {
  * }
  * ```
  */
-export function useTransactions({ hashes }: UseTransactionsArgs): UseTransactionResult[] {
+export function useTransactions({
+  hashes,
+  watch = false,
+}: UseTransactionsArgs): UseTransactionResult[] {
   const { library } = useStarknet()
   const result = useQueries({
     queries: hashes.map((hash) => ({
@@ -141,6 +145,11 @@ export function useTransactions({ hashes }: UseTransactionsArgs): UseTransaction
         hash,
       }),
     })),
+  })
+
+  useInvalidateOnBlock({
+    enabled: watch,
+    queryKey: [{ entity: 'transaction', chainId: library?.chainId }],
   })
 
   return result.map(


### PR DESCRIPTION
We use react-query `invalidateQueries` to invalidate queries on new blocks. 
Since this can result in a lot of RPC calls, we hide it behind a `watch` flag.

Fix #247
