### PR TITLE
fix: request AccountInterface v4 to injected wallets

### DIFF
--- a/.changeset/strong-dolls-obey.md
+++ b/.changeset/strong-dolls-obey.md
@@ -1,0 +1,5 @@
+---
+'@starknet-react/core': minor
+---
+
+Request AccountInterface v4 to injected wallets

--- a/packages/core/src/connectors/base.ts
+++ b/packages/core/src/connectors/base.ts
@@ -1,5 +1,5 @@
+import { AccountChangeEventHandler } from 'get-starknet-core'
 import { AccountInterface } from 'starknet'
-import { EventHandler } from './injected'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export abstract class Connector<Options = any> {
@@ -17,8 +17,8 @@ export abstract class Connector<Options = any> {
   abstract ready(): Promise<boolean>
   abstract connect(): Promise<AccountInterface>
   abstract disconnect(): Promise<void>
-  abstract initEventListener(accountChangeCb: EventHandler): Promise<void>
-  abstract removeEventListener(accountChangeCb: EventHandler): Promise<void>
+  abstract initEventListener(accountChangeCb: AccountChangeEventHandler): Promise<void>
+  abstract removeEventListener(accountChangeCb: AccountChangeEventHandler): Promise<void>
   abstract account(): Promise<AccountInterface | null>
   /** Unique connector id */
   abstract id(): string

--- a/packages/core/src/connectors/index.ts
+++ b/packages/core/src/connectors/index.ts
@@ -1,8 +1,2 @@
 export { Connector } from './base'
-export {
-  InjectedConnector,
-  type InjectedConnectorOptions,
-  type IStarknetWindowObject,
-  type EventHandler,
-  type EventType,
-} from './injected'
+export { InjectedConnector, type InjectedConnectorOptions } from './injected'


### PR DESCRIPTION
Sometimes we would get different values based on the type of wallet
connected (Argent X or Braavos).
By specifying that we want v4, we will always receive the correct value.
