### PR TITLE
fix: handle network changes in useNetwork hook

### DIFF
--- a/.changeset/cuddly-berries-listen.md
+++ b/.changeset/cuddly-berries-listen.md
@@ -1,0 +1,5 @@
+---
+'@starknet-react/core': patch
+---
+
+Fix useNetwork hook

--- a/.github/PULL_REQUEST_TEMPLATE/default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default.md
@@ -1,0 +1,5 @@
+## Context
+
+## Changes in this Pull Request
+
+## Test Plan

--- a/packages/core/src/hooks/network.ts
+++ b/packages/core/src/hooks/network.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+import { useEffect, useState } from 'react'
 import { useStarknet } from '../providers'
 import { chainById, Chain } from '../network'
 
@@ -27,14 +27,17 @@ export interface UseNetworkResult {
  */
 export function useNetwork(): UseNetworkResult {
   const { library } = useStarknet()
+  const [chain, setChain] = useState<Chain>()
 
-  const { data: chain } = useQuery([], async () => {
-    if (!library) {
-      return undefined
+  useEffect(() => {
+    if (library) {
+      library.getChainId().then((chainId) => setChain(chainById(chainId)))
+    } else {
+      // library should be always defined, but if it's not then
+      // we reset the chain to undefined.
+      setChain(undefined)
     }
-
-    return chainById(await library.getChainId())
-  })
+  }, [library])
 
   return { chain }
 }


### PR DESCRIPTION
## Context

This PR fixes #283

## Changes in this Pull Request

Replaced the use of `useQuery` with `useEffect` and `useState` to refresh the
value of the chain id when the provider changes.

## Test Plan

 - Run `pnpm dev:web` to start the documentation
 - Opened the `useNetwork` hook page
 - Connected Argent X, changed network and verified the network name changes
   * This one is not working, but it's a bug in Argent.
 - Connected Braavos, changed network and verified the network name changes

