### PR TITLE
Custom headers for jsonRpcProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ import {
 
 function App() {
   const chains = [goerli];
-  const providers = [publicProvider()];
+  const provider = publicProvider();
   const connectors = [braavos(), argent()];
 
   return (
-    <StarknetConfig chains={chains} providers={providers} connectors={connectors}>
+    <StarknetConfig chains={chains} provider={provider} connectors={connectors}>
       <YourApp />
     </StarknetConfig>
   )

--- a/packages/chains/src/types.ts
+++ b/packages/chains/src/types.ts
@@ -47,5 +47,6 @@ export type NativeCurrency = {
 
 export type RpcUrls = {
   http: readonly string[];
+  headers?: object;
   websocket?: readonly string[];
 };

--- a/packages/chains/src/types.ts
+++ b/packages/chains/src/types.ts
@@ -47,6 +47,5 @@ export type NativeCurrency = {
 
 export type RpcUrls = {
   http: readonly string[];
-  headers?: object;
   websocket?: readonly string[];
 };

--- a/packages/core/src/context/index.tsx
+++ b/packages/core/src/context/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import { StarknetProvider, StarknetProviderProps } from "./starknet";
 
+export { starknetChainId } from "./starknet";
 export { AccountProvider as OverrideAccount } from "./account";
 
 export type StarknetConfigProps = StarknetProviderProps;

--- a/packages/core/src/context/starknet.tsx
+++ b/packages/core/src/context/starknet.tsx
@@ -283,7 +283,7 @@ function useStarknetManager({
 export interface StarknetProviderProps {
   /** Chains supported by the app. */
   chains: Chain[];
-  /** Providers supported by the app. */
+  /** Provider to use. */
   provider: ChainProviderFactory;
   /** List of connectors to use. */
   connectors?: Connector[];

--- a/packages/core/src/context/starknet.tsx
+++ b/packages/core/src/context/starknet.tsx
@@ -332,8 +332,9 @@ function providerForChain(
       if (!nodeUrl) {
         continue;
       }
+      const headers = rpcUrls.headers;
       const chainId = starknetChainId(chain.id);
-      const rpc = new RpcProvider({ nodeUrl, chainId });
+      const rpc = new RpcProvider({ nodeUrl, chainId, headers });
       return { chain, provider: rpc };
     }
   }

--- a/packages/core/src/context/starknet.tsx
+++ b/packages/core/src/context/starknet.tsx
@@ -332,7 +332,7 @@ function providerForChain(
   throw new Error(`No provider found for chain ${chain.name}`);
 }
 
-function starknetChainId(
+export function starknetChainId(
   chainId: bigint,
 ): constants.StarknetChainId | undefined {
   switch (chainId) {

--- a/packages/core/src/providers/alchemy.ts
+++ b/packages/core/src/providers/alchemy.ts
@@ -1,4 +1,3 @@
-import { ChainProviderFactory } from "./factory";
 import { jsonRpcProvider } from "./jsonrpc";
 
 /** Arguments for `alchemyProvider`. */
@@ -8,9 +7,7 @@ export type AlchemyProviderArgs = {
 };
 
 /** Configure the Alchemy provider using the provided API key. */
-export function alchemyProvider({
-  apiKey,
-}: AlchemyProviderArgs): ChainProviderFactory {
+export function alchemyProvider({ apiKey }: AlchemyProviderArgs) {
   return jsonRpcProvider({
     rpc: chain => {
       const baseHttpUrl = chain.rpcUrls["alchemy"]?.http[0];

--- a/packages/core/src/providers/alchemy.ts
+++ b/packages/core/src/providers/alchemy.ts
@@ -1,4 +1,5 @@
-import { ChainProviderFactory, setDefaultRpcUrl } from "./factory";
+import { ChainProviderFactory } from "./factory";
+import { jsonRpcProvider } from "./jsonrpc";
 
 /** Arguments for `alchemyProvider`. */
 export type AlchemyProviderArgs = {
@@ -10,15 +11,12 @@ export type AlchemyProviderArgs = {
 export function alchemyProvider({
   apiKey,
 }: AlchemyProviderArgs): ChainProviderFactory {
-  return function (chain) {
-    const baseHttpUrl = chain.rpcUrls["alchemy"]?.http[0];
-    if (!baseHttpUrl) return null;
-    const httpUrl = `${baseHttpUrl}/${apiKey}`;
-    return {
-      chain: setDefaultRpcUrl(chain, httpUrl),
-      rpcUrls: {
-        http: [httpUrl],
-      },
-    };
-  };
+  return jsonRpcProvider({
+    rpc: chain => {
+      const baseHttpUrl = chain.rpcUrls["alchemy"]?.http[0];
+      if (!baseHttpUrl) return null;
+      const nodeUrl = `${baseHttpUrl}/${apiKey}`;
+      return { nodeUrl };
+    }
+  });
 }

--- a/packages/core/src/providers/factory.ts
+++ b/packages/core/src/providers/factory.ts
@@ -1,17 +1,4 @@
-import { Chain, RpcUrls } from "@starknet-react/chains";
+import { Chain } from "@starknet-react/chains";
+import { ProviderInterface } from "starknet";
 
-export type ChainProviderFactory = (chain: Chain) => {
-  chain: Chain;
-  rpcUrls: RpcUrls;
-} | null;
-
-/** Returns a new chain with the default RPC URL set. */
-export function setDefaultRpcUrl(chain: Chain, url: string): Chain {
-  return {
-    ...chain,
-    rpcUrls: {
-      ...chain.rpcUrls,
-      default: { http: [url] },
-    },
-  };
-}
+export type ChainProviderFactory = (chain: Chain) => ProviderInterface | null;

--- a/packages/core/src/providers/factory.ts
+++ b/packages/core/src/providers/factory.ts
@@ -1,4 +1,4 @@
 import { Chain } from "@starknet-react/chains";
 import { ProviderInterface } from "starknet";
 
-export type ChainProviderFactory = (chain: Chain) => ProviderInterface | null;
+export type ChainProviderFactory<T extends ProviderInterface = ProviderInterface> = (chain: Chain) => T | null;

--- a/packages/core/src/providers/infura.ts
+++ b/packages/core/src/providers/infura.ts
@@ -1,4 +1,5 @@
-import { ChainProviderFactory, setDefaultRpcUrl } from "./factory";
+import { ChainProviderFactory } from "./factory";
+import { jsonRpcProvider } from "./jsonrpc";
 
 /** Arguments for `infuraProvider`. */
 export type InfuraProviderArgs = {
@@ -10,15 +11,12 @@ export type InfuraProviderArgs = {
 export function infuraProvider({
   apiKey,
 }: InfuraProviderArgs): ChainProviderFactory {
-  return function (chain) {
-    const baseHttpUrl = chain.rpcUrls["infura"]?.http[0];
-    if (!baseHttpUrl) return null;
-    const httpUrl = `${baseHttpUrl}/${apiKey}`;
-    return {
-      chain: setDefaultRpcUrl(chain, httpUrl),
-      rpcUrls: {
-        http: [httpUrl],
-      },
-    };
-  };
+  return jsonRpcProvider({
+    rpc: chain => {
+      const baseHttpUrl = chain.rpcUrls["infura"]?.http[0];
+      if (!baseHttpUrl) return null;
+      const nodeUrl = `${baseHttpUrl}/${apiKey}`;
+      return { nodeUrl };
+    }
+  });
 }

--- a/packages/core/src/providers/infura.ts
+++ b/packages/core/src/providers/infura.ts
@@ -1,4 +1,3 @@
-import { ChainProviderFactory } from "./factory";
 import { jsonRpcProvider } from "./jsonrpc";
 
 /** Arguments for `infuraProvider`. */
@@ -8,9 +7,7 @@ export type InfuraProviderArgs = {
 };
 
 /** Configure the Infura provider using the provided API key. */
-export function infuraProvider({
-  apiKey,
-}: InfuraProviderArgs): ChainProviderFactory {
+export function infuraProvider({ apiKey }: InfuraProviderArgs) {
   return jsonRpcProvider({
     rpc: chain => {
       const baseHttpUrl = chain.rpcUrls["infura"]?.http[0];

--- a/packages/core/src/providers/jsonrpc.test.ts
+++ b/packages/core/src/providers/jsonrpc.test.ts
@@ -5,18 +5,12 @@ import { jsonRpcProvider } from "./jsonrpc";
 
 function rpc(chain: Chain) {
   return {
-    http: `https://${chain.network}.example.com`,
+    nodeUrl: `https://${chain.network}.example.com`,
   };
 }
 
-describe("publicProvider", () => {
+describe("jsonRpcProvider", () => {
   it("returns a public rpc endpoint", () => {
-    expect(jsonRpcProvider({ rpc })(mainnet)?.rpcUrls).toMatchInlineSnapshot(`
-      {
-        "http": [
-          "https://mainnet.example.com",
-        ],
-      }
-    `);
+    expect(jsonRpcProvider({ rpc })(mainnet)?.nodeUrl).toMatchInlineSnapshot('"https://mainnet.example.com"');
   });
 });

--- a/packages/core/src/providers/jsonrpc.ts
+++ b/packages/core/src/providers/jsonrpc.ts
@@ -18,7 +18,7 @@ export function jsonRpcProvider({
       chain: setDefaultRpcUrl(chain, config.http),
       rpcUrls: {
         http: [config.http],
-        headers: config.headers
+        ...config.headers && { headers: config.headers }
       },
     };
   };

--- a/packages/core/src/providers/jsonrpc.ts
+++ b/packages/core/src/providers/jsonrpc.ts
@@ -11,7 +11,7 @@ export type JsonRpcProviderArgs = {
 /** Configure the JSON-RPC provider using the provided function. */
 export function jsonRpcProvider({
   rpc,
-}: JsonRpcProviderArgs): ChainProviderFactory {
+}: JsonRpcProviderArgs): ChainProviderFactory<RpcProvider> {
   return function (chain) {
     const config = rpc(chain);
     if (!config) return null;

--- a/packages/core/src/providers/jsonrpc.ts
+++ b/packages/core/src/providers/jsonrpc.ts
@@ -4,7 +4,7 @@ import { ChainProviderFactory, setDefaultRpcUrl } from "./factory";
 
 /** Arguments for `jsonRpcProvider`. */
 export type JsonRpcProviderArgs = {
-  rpc: (chain: Chain) => { http: string } | null;
+  rpc: (chain: Chain) => { http: string; headers?: object; } | null;
 };
 
 /** Configure the JSON-RPC provider using the provided function. */
@@ -18,6 +18,7 @@ export function jsonRpcProvider({
       chain: setDefaultRpcUrl(chain, config.http),
       rpcUrls: {
         http: [config.http],
+        headers: config.headers
       },
     };
   };

--- a/packages/core/src/providers/jsonrpc.ts
+++ b/packages/core/src/providers/jsonrpc.ts
@@ -1,6 +1,7 @@
 import { Chain } from "@starknet-react/chains";
 import { RpcProvider, RpcProviderOptions } from "starknet";
 
+import { starknetChainId } from "~/context";
 import { ChainProviderFactory } from "./factory";
 
 /** Arguments for `jsonRpcProvider`. */
@@ -15,8 +16,9 @@ export function jsonRpcProvider({
   return function (chain) {
     const config = rpc(chain);
     if (!config) return null;
-    
-    const provider = new RpcProvider(config);
+    const chainId = starknetChainId(chain.id);
+
+    const provider = new RpcProvider({ ...config, chainId });
     return provider;
   };
 }

--- a/packages/core/src/providers/jsonrpc.ts
+++ b/packages/core/src/providers/jsonrpc.ts
@@ -1,10 +1,11 @@
 import { Chain } from "@starknet-react/chains";
+import { RpcProvider, RpcProviderOptions } from "starknet";
 
-import { ChainProviderFactory, setDefaultRpcUrl } from "./factory";
+import { ChainProviderFactory } from "./factory";
 
 /** Arguments for `jsonRpcProvider`. */
 export type JsonRpcProviderArgs = {
-  rpc: (chain: Chain) => { http: string; headers?: object; } | null;
+  rpc: (chain: Chain) => RpcProviderOptions | null;
 };
 
 /** Configure the JSON-RPC provider using the provided function. */
@@ -13,13 +14,9 @@ export function jsonRpcProvider({
 }: JsonRpcProviderArgs): ChainProviderFactory {
   return function (chain) {
     const config = rpc(chain);
-    if (!config || config.http === "") return null;
-    return {
-      chain: setDefaultRpcUrl(chain, config.http),
-      rpcUrls: {
-        http: [config.http],
-        ...config.headers && { headers: config.headers }
-      },
-    };
+    if (!config) return null;
+    
+    const provider = new RpcProvider(config);
+    return provider;
   };
 }

--- a/packages/core/src/providers/lava.ts
+++ b/packages/core/src/providers/lava.ts
@@ -1,4 +1,5 @@
-import { ChainProviderFactory, setDefaultRpcUrl } from "./factory";
+import { ChainProviderFactory } from "./factory";
+import { jsonRpcProvider } from "./jsonrpc";
 
 /** Arguments for `lavaProvider`. */
 export type LavaProviderArgs = {
@@ -10,15 +11,12 @@ export type LavaProviderArgs = {
 export function lavalProvider({
   apiKey,
 }: LavaProviderArgs): ChainProviderFactory {
-  return function (chain) {
-    const baseHttpUrl = chain.rpcUrls["lava"]?.http[0];
-    if (!baseHttpUrl) return null;
-    const httpUrl = `${baseHttpUrl}/${apiKey}`;
-    return {
-      chain: setDefaultRpcUrl(chain, httpUrl),
-      rpcUrls: {
-        http: [httpUrl],
-      },
-    };
-  };
+  return jsonRpcProvider({
+    rpc: chain => {
+      const baseHttpUrl = chain.rpcUrls["lava"]?.http[0];
+      if (!baseHttpUrl) return null;
+      const nodeUrl = `${baseHttpUrl}/${apiKey}`;
+      return { nodeUrl };
+    }
+  });
 }

--- a/packages/core/src/providers/lava.ts
+++ b/packages/core/src/providers/lava.ts
@@ -1,4 +1,3 @@
-import { ChainProviderFactory } from "./factory";
 import { jsonRpcProvider } from "./jsonrpc";
 
 /** Arguments for `lavaProvider`. */
@@ -8,9 +7,7 @@ export type LavaProviderArgs = {
 };
 
 /** Configure the Lava provider using the provided API key. */
-export function lavalProvider({
-  apiKey,
-}: LavaProviderArgs): ChainProviderFactory {
+export function lavalProvider({ apiKey }: LavaProviderArgs) {
   return jsonRpcProvider({
     rpc: chain => {
       const baseHttpUrl = chain.rpcUrls["lava"]?.http[0];

--- a/packages/core/src/providers/public.test.ts
+++ b/packages/core/src/providers/public.test.ts
@@ -7,4 +7,8 @@ describe("publicProvider", () => {
   it("returns a public rpc endpoint", () => {
     expect(publicProvider()(devnet)?.nodeUrl).toMatchInlineSnapshot('"http://localhost:5050/rpc"');
   });
+
+  it("returns the chain", () => {
+    expect(publicProvider()(devnet)?.getChainId()).resolves.toMatch('0x534e5f474f45524c49');
+  });
 });

--- a/packages/core/src/providers/public.test.ts
+++ b/packages/core/src/providers/public.test.ts
@@ -5,39 +5,6 @@ import { publicProvider } from "./public";
 
 describe("publicProvider", () => {
   it("returns a public rpc endpoint", () => {
-    expect(publicProvider()(devnet)?.rpcUrls).toMatchInlineSnapshot(`
-      {
-        "http": [
-          "http://localhost:5050/rpc",
-        ],
-      }
-    `);
-  });
-
-  it("returns the chain", () => {
-    expect(publicProvider()(devnet)?.chain).toMatchInlineSnapshot(`
-      {
-        "id": 1536727068981429685321n,
-        "name": "Starknet Devnet",
-        "nativeCurrency": {
-          "address": "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-          "decimals": 18,
-          "name": "Ether",
-          "symbol": "ETH",
-        },
-        "network": "devnet",
-        "rpcUrls": {
-          "default": {
-            "http": [],
-          },
-          "public": {
-            "http": [
-              "http://localhost:5050/rpc",
-            ],
-          },
-        },
-        "testnet": true,
-      }
-    `);
+    expect(publicProvider()(devnet)?.nodeUrl).toMatchInlineSnapshot('"http://localhost:5050/rpc"');
   });
 });

--- a/packages/core/src/providers/public.ts
+++ b/packages/core/src/providers/public.ts
@@ -1,8 +1,7 @@
-import { ChainProviderFactory } from "./factory";
 import { jsonRpcProvider } from "./jsonrpc";
 
 /** Configure the provider to use the public RPC endpoint. */
-export function publicProvider(): ChainProviderFactory {
+export function publicProvider() {
   return jsonRpcProvider({
     rpc: chain => {
       const nodeUrl = chain.rpcUrls.public.http[0];

--- a/packages/core/src/providers/public.ts
+++ b/packages/core/src/providers/public.ts
@@ -1,12 +1,13 @@
 import { ChainProviderFactory } from "./factory";
+import { jsonRpcProvider } from "./jsonrpc";
 
 /** Configure the provider to use the public RPC endpoint. */
 export function publicProvider(): ChainProviderFactory {
-  return function (chain) {
-    if (!chain.rpcUrls.public.http[0]) return null;
-    return {
-      chain,
-      rpcUrls: chain.rpcUrls.public,
-    };
-  };
+  return jsonRpcProvider({
+    rpc: chain => {
+      const nodeUrl = chain.rpcUrls.public.http[0];
+      if (!nodeUrl) return null;
+      return { nodeUrl };
+    }
+  });
 }

--- a/packages/core/test/react.tsx
+++ b/packages/core/test/react.tsx
@@ -15,7 +15,7 @@ import { defaultConnector } from "./devnet";
 
 function StarknetConfig({ children }: { children: React.ReactNode }) {
   const chains = [devnet, mainnet];
-  const providers = [publicProvider()];
+  const provider = publicProvider();
   const connectors = [defaultConnector];
 
   const queryClient = new QueryClient({
@@ -34,7 +34,7 @@ function StarknetConfig({ children }: { children: React.ReactNode }) {
   return (
     <OgStarknetConfig
       chains={chains}
-      providers={providers}
+      provider={provider}
       connectors={connectors}
       queryClient={queryClient}
     >

--- a/website/components/starknet/provider.tsx
+++ b/website/components/starknet/provider.tsx
@@ -12,7 +12,7 @@ import {
 
 export function StarknetProvider({ children }: { children: React.ReactNode }) {
   const chains = [goerli, mainnet];
-  const providers = [publicProvider()];
+  const provider = publicProvider();
   const { connectors } = useInjectedConnectors({
     // Show these connectors if the user has no connector installed.
     recommended: [
@@ -28,7 +28,7 @@ export function StarknetProvider({ children }: { children: React.ReactNode }) {
   return (
     <StarknetConfig
       chains={chains}
-      providers={providers}
+      provider={provider}
       connectors={connectors}
     >
       {children}

--- a/website/content/docs/getting-started.mdx
+++ b/website/content/docs/getting-started.mdx
@@ -70,7 +70,7 @@ import {
 
 export function StarknetProvider({ children }: { children: React.ReactNode }) {
   const chains = [goerli];
-  const providers = [publicProvider()];
+  const provider = publicProvider();
   const { connectors } = useInjectedConnectors({
     // Show these connectors if the user has no connector installed.
     recommended: [
@@ -86,7 +86,7 @@ export function StarknetProvider({ children }: { children: React.ReactNode }) {
   return (
     <StarknetConfig
       chains={chains}
-      providers={providers}
+      provider={provider}
       connectors={connectors}
     >
       {children}

--- a/website/content/docs/getting-started.mdx
+++ b/website/content/docs/getting-started.mdx
@@ -47,7 +47,7 @@ The next step is to configure the Starknet provider. You need to configure the
 following:
 
  - _chains_: a list of chains supported by your dapp.
- - _providers_: the JSON-RPC provider you want to use. See the
+ - _provider_: the JSON-RPC provider you want to use. See the
    [providers](/docs/providers) page for more information.
  - _connectors_: the wallet connectors supported by your dapp. See
  the [wallets](/docs/wallets) page for more information.

--- a/website/content/docs/providers.mdx
+++ b/website/content/docs/providers.mdx
@@ -35,9 +35,7 @@ function rpc(chain: Chain) {
   }
 }
 
-const providers = [
-  jsonRpcProvider({ rpc })
-];
+const provider = jsonRpcProvider({ rpc });
 ```
 
 ### Alchemy
@@ -47,9 +45,7 @@ Create an Alchemy API key from the dashboard.
 ```ts
 import { alchemyProvider } from "@starknet-react/core";
 
-const providers = [
-  alchemyProvider({ apiKey })
-];
+const provider = alchemyProvider({ apiKey });
 ```
 
 ### Infura
@@ -59,9 +55,7 @@ Create an Infura API key from the dashboard.
 ```ts
 import { infuraProvider } from "@starknet-react/core";
 
-const providers = [
-  infuraProvider({ apiKey })
-];
+const provider = infuraProvider({ apiKey });
 ```
 
 ### Lava
@@ -71,7 +65,5 @@ Create a Lava API key from the dashboard.
 ```ts
 import { lavaProvider } from "@starknet-react/core";
 
-const providers = [
-  lavaProvider({ apiKey })
-];
+const provider = lavaProvider({ apiKey });
 ```

--- a/website/content/docs/upgrading.mdx
+++ b/website/content/docs/upgrading.mdx
@@ -24,12 +24,12 @@ yarn add @starknet-react/chains@next @starknet-react/core@next starknet get-star
 
 ## Update `StarknetConfig`
 
-Update the existing `StarknetConfig` by adding the new `chains` and `providers`
+Update the existing `StarknetConfig` by adding the new `chains` and `provider`
 options. You also need to update the `connectors` passed to it.
 
  - `chains`: a list of chains supported by your dapp. The first chain in the
    list is the default chain, used when the user doesn't connect their wallet.
- - `providers`: an RPC provider. See the [providers](/docs/providers) section
+ - `provider`: an RPC provider. See the [providers](/docs/providers) section
    for more information.
  - `connectors`: in v2, basic information about a wallet (like the id and name)
    must be provided. Starknet React provides helpers to initialize connectors

--- a/website/content/docs/upgrading.mdx
+++ b/website/content/docs/upgrading.mdx
@@ -46,13 +46,13 @@ import {
 
 export function StarknetProvider({ children }: { children: React.ReactNode }) {
   const chains = [goerli];
-  const providers = [publicProvider()];
+  const provider = publicProvider();
   const connectors = [argent(), braavos()];
 
   return (
     <StarknetConfig
       chains={chains}
-      providers={providers}
+      provider={provider}
       connectors={connectors}
     >
       {children}

--- a/website/content/hooks/useInjectedConnectors.mdx
+++ b/website/content/hooks/useInjectedConnectors.mdx
@@ -18,7 +18,7 @@ import {
 
 export default function App({ children }) {
   const chains = [goerli, mainnet];
-  const providers = [publicProvider()];
+  const provider = publicProvider();
   const { connectors } = useInjectedConnectors({
     // Show these connectors if the user has no connector installed.
     recommended: [
@@ -34,7 +34,7 @@ export default function App({ children }) {
   return (
     <StarknetConfig
       chains={chains}
-      providers={providers}
+      provider={provider}
       connectors={connectors}
     >
       {children}


### PR DESCRIPTION
adds functionality to pass headers as arguments to jsonRpcProvider. this is useful as some rpcs require passing the auth token in a header