### PR TITLE
feat: add useStarkProfile hook

### DIFF
--- a/.changeset/violet-lizards-give.md
+++ b/.changeset/violet-lizards-give.md
@@ -1,0 +1,5 @@
+---
+"@starknet-react/core": minor
+---
+
+Add useStarkProfile hook

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -16,3 +16,4 @@ export * from "./useSign";
 export * from "./useStarkAddress";
 export * from "./useStarkName";
 export * from "./useWaitForTransaction";
+export * from "./useStarkProfile";

--- a/packages/core/src/hooks/useStarkProfile.ts
+++ b/packages/core/src/hooks/useStarkProfile.ts
@@ -336,7 +336,7 @@ const StarknetIdcontracts: Record<string, Record<string, string>> = {
     verifier_pfp:
       "0x03cac3228b434259734ee0e4ff445f642206ea11adace7e4f45edd2596748698",
     multicall:
-      "0x6e2b0049610266f5acfb899b2de1a121a0d65e86330ae38b6287e0e4b80a42",
+      "0x034ffb8f4452df7a613a0210824d6414dbadcddce6c6e19bf4ddc9e22ce5f970",
   },
   mainnet: {
     naming: "0x6ac597f8116f886fa1c97a23fa4e08299975ecaf6b598873ca6792b9bbfb678",
@@ -348,7 +348,8 @@ const StarknetIdcontracts: Record<string, Record<string, string>> = {
       "0x0293eb2ba9862f762bd3036586d5755a782bd22e6f5028320f1d0405fd47bff4",
     verifier_pfp:
       "0x070aaa20ec4a46da57c932d9fd89ca5e6bb9ca3188d3df361a32306aff7d59c7",
-    multicall: "", // todo: deploy on mainnet and add address
+    multicall:
+      "0x034ffb8f4452df7a613a0210824d6414dbadcddce6c6e19bf4ddc9e22ce5f970",
   },
 };
 

--- a/packages/core/src/hooks/useStarkProfile.ts
+++ b/packages/core/src/hooks/useStarkProfile.ts
@@ -23,8 +23,8 @@ export type StarkProfileArgs = UseQueryProps<
 > & {
   /** Account address. */
   address?: string;
-  /** Get Starknet ID identicons if no profile picture is set */
-  identicons?: boolean;
+  /** Get Starknet ID default pfp url if no profile picture is set */
+  useDefaultPfp?: boolean;
   /** Naming contract to use. */
   namingContract?: string;
   /** Identity contract to use. */
@@ -82,12 +82,12 @@ export type useStarkProfileResult = UseQueryResult<
  * ```
  *
  *  @example
- * This example shows how to get the stark profile of an address enabling identicons and specifying a
+ * This example shows how to get the stark profile of an address disabling useDefaultPfp and specifying a
  * different naming and identity contract addresses
  * ```tsx
  * function Component() {
  *   const address = '0x061b6c0a78f9edf13cea17b50719f3344533fadd470b8cb29c2b4318014f52d3'
- *   const { data, isLoading, isError } = useStarkProfile({ address, identicons: true, namingContract: '0x1234', identityContract: '0x5678' })
+ *   const { data, isLoading, isError } = useStarkProfile({ address, useDefaultPfp: false, namingContract: '0x1234', identityContract: '0x5678' })
  *
  *   if (isLoading) return <span>Loading...</span>
  *   if (isError) return <span>Error fetching profile...</span>
@@ -105,7 +105,7 @@ export type useStarkProfileResult = UseQueryResult<
  */
 export function useStarkProfile({
   address,
-  identicons = false,
+  useDefaultPfp = true,
   namingContract,
   identityContract,
   enabled: enabled_ = true,
@@ -127,7 +127,7 @@ export function useStarkProfile({
     queryKey: queryKey({ address, namingContract, identityContract }),
     queryFn: queryFn({
       address,
-      identicons,
+      useDefaultPfp,
       namingContract,
       provider,
       network: chain.network,
@@ -155,7 +155,7 @@ function queryKey({
 
 function queryFn({
   address,
-  identicons,
+  useDefaultPfp,
   namingContract,
   identityContract,
   provider,
@@ -292,7 +292,7 @@ function queryFn({
       // extract nft_image from profile data
       const profilePicture = profile
         ? await fetchImageUrl(profile)
-        : identicons
+        : useDefaultPfp
         ? `https://starknet.id/api/identicons/${data[1][0].toString()}`
         : undefined;
 

--- a/packages/core/src/hooks/useStarkProfile.ts
+++ b/packages/core/src/hooks/useStarkProfile.ts
@@ -1,0 +1,401 @@
+import { useMemo } from "react";
+import {
+  CairoCustomEnum,
+  ContractInterface,
+  Provider,
+  ProviderInterface,
+  cairo,
+  hash,
+  shortString,
+} from "starknet";
+
+import { UseQueryProps, UseQueryResult, useQuery } from "~/query";
+import { useProvider } from "./useProvider";
+import { useContract } from "./useContract";
+import { useNetwork } from "./useNetwork";
+
+/** Arguments for `useStarkProfile` hook. */
+export type StarkProfileArgs = UseQueryProps<
+  GetStarkprofileResponse,
+  unknown,
+  GetStarkprofileResponse,
+  ReturnType<typeof queryKey>
+> & {
+  /** Account address. */
+  address?: string;
+  /** Naming contract to use. */
+  namingContract?: string;
+  /** Identity contract to use. */
+  identityContract?: string;
+};
+
+/** Value returned by `useStarkProfile` hook. */
+type GetStarkprofileResponse = {
+  name?: string;
+  /** Profile picture metadata. */
+  profilePicture?: string;
+  twitter?: string;
+  github?: string;
+  discord?: string;
+  proofOfPersonhood?: boolean;
+};
+export type useStarkProfileResult = UseQueryResult<
+  GetStarkprofileResponse,
+  unknown
+>;
+
+/**
+ * Hook for fetching Stark profile for address.
+ *
+ * @remarks
+ *
+ * This hook fetches the stark name of the specified address, profile picture url,
+ * social networks ids, and proof of personhood a user has set on its starknetid.
+ * It defaults to the starknet.id naming and identity contracts but different contracts can be
+ * targetted by specifying their contract addresses
+ * If address does not have a stark name, it will return "stark"
+ *
+ * @example
+ * This example shows how to get the stark profile of an address using the default
+ * Starknet.id contracts
+ * ```tsx
+ * function Component() {
+ *   const address = '0x061b6c0a78f9edf13cea17b50719f3344533fadd470b8cb29c2b4318014f52d3'
+ *   const { data, isLoading, isError } = useStarkProfile({ address })
+ *
+ *   if (isLoading) return <span>Loading...</span>
+ *   if (isError) return <span>Error fetching stark profile...</span>
+ *   return (
+ *      <span>name: {data?.name}</span>
+ *      <span>Profile picture metadata uri : {data?.profilePicture}</span>
+ *      <span>Discord id: {data?.discord}</span>
+ *      <span>Twitter id: {data?.twitter}</span>
+ *      <span>Github id: {data?.github}</span>
+ *      <span>Proof of personhood verification: {data?.proofOfPersonhood}</span>
+ *    )
+ * }
+ * ```
+ *
+ *  @example
+ * This example shows how to get the stark profile of an address specifying a
+ * different naming and identity contract addresses
+ * ```tsx
+ * function Component() {
+ *   const address = '0x061b6c0a78f9edf13cea17b50719f3344533fadd470b8cb29c2b4318014f52d3'
+ *   const { data, isLoading, isError } = useStarkName({ address, namingContract: '0x1234', identityContract: '0x5678' })
+ *
+ *   if (isLoading) return <span>Loading...</span>
+ *   if (isError) return <span>Error fetching profile...</span>
+ *   return (
+ *      <span>name: {data?.name}</span>
+ *      <span>Profile picture metadata uri : {data?.profilePicture}</span>
+ *      <span>Discord id: {data?.discord}</span>
+ *      <span>Twitter id: {data?.twitter}</span>
+ *      <span>Github id: {data?.github}</span>
+ *      <span>Proof of personhood verification: {data?.proofOfPersonhood}</span>
+ *    )
+ * }
+ * ```
+ */
+export function useStarkProfile({
+  address,
+  namingContract,
+  identityContract,
+  enabled: enabled_ = true,
+  ...props
+}: StarkProfileArgs): useStarkProfileResult {
+  const { provider } = useProvider();
+  const { chain } = useNetwork();
+  const { contract: multicallContract } = useContract({
+    abi: multicallABI,
+    address: (StarknetIdcontracts[chain.network] as any)["multicall"],
+  });
+
+  const enabled = useMemo(
+    () => Boolean(enabled_ && address),
+    [enabled_, address]
+  );
+
+  return useQuery({
+    queryKey: queryKey({ address, namingContract, identityContract }),
+    queryFn: queryFn({
+      address,
+      namingContract,
+      provider,
+      network: chain.network,
+      identityContract,
+      multicallContract,
+    }),
+    enabled,
+    ...props,
+  });
+}
+
+function queryKey({
+  address,
+  namingContract,
+  identityContract,
+}: {
+  address?: string;
+  namingContract?: string;
+  identityContract?: string;
+}) {
+  return [
+    { entity: "starkprofile", address, namingContract, identityContract },
+  ] as const;
+}
+
+function queryFn({
+  address,
+  namingContract,
+  identityContract,
+  provider,
+  network,
+  multicallContract,
+}: StarkProfileArgs & { provider: ProviderInterface } & { network?: string } & {
+  multicallContract?: ContractInterface;
+}) {
+  return async function () {
+    if (!address) throw new Error("address is required");
+    if (!multicallContract) throw new Error("multicallContract is required");
+    if (!network) throw new Error("network is required");
+
+    const contracts = StarknetIdcontracts[network] as Record<string, string>;
+    const identity = identityContract ?? (contracts["identity"] as string);
+    const naming = namingContract ?? (contracts["naming"] as string);
+
+    // get decoded starkname
+    const p = new Provider(provider);
+    const name = await p.getStarkName(address, naming);
+
+    const data = await multicallContract.call("aggregate", [
+      [
+        {
+          to: hardcoded(naming),
+          selector: hardcoded(hash.getSelectorFromName("address_to_domain")),
+          calldata: [hardcoded(address)],
+        },
+        {
+          to: hardcoded(naming),
+          selector: hardcoded(hash.getSelectorFromName("domain_to_token_id")),
+          calldata: [arrayReference(0, 0)],
+        },
+        {
+          to: hardcoded(identity),
+          selector: hardcoded(hash.getSelectorFromName("get_verifier_data")),
+          calldata: [
+            reference(1, 0),
+            hardcoded(shortString.encodeShortString("twitter")),
+            hardcoded(contracts["verifier"] as string),
+            hardcoded("0"),
+          ],
+        },
+        {
+          to: hardcoded(identity),
+          selector: hardcoded(hash.getSelectorFromName("get_verifier_data")),
+          calldata: [
+            reference(1, 0),
+            hardcoded(shortString.encodeShortString("github")),
+            hardcoded(contracts["verifier"] as string),
+            hardcoded("0"),
+          ],
+        },
+        {
+          to: hardcoded(identity),
+          selector: hardcoded(hash.getSelectorFromName("get_verifier_data")),
+          calldata: [
+            reference(1, 0),
+            hardcoded(shortString.encodeShortString("discord")),
+            hardcoded(contracts["verifier"] as string),
+            hardcoded("0"),
+          ],
+        },
+        {
+          to: hardcoded(identity),
+          selector: hardcoded(hash.getSelectorFromName("get_verifier_data")),
+          calldata: [
+            reference(1, 0),
+            hardcoded(shortString.encodeShortString("proof_of_personhood")),
+            hardcoded(contracts["verifier_pop"] as string),
+            hardcoded("0"),
+          ],
+        },
+        // PFP
+        {
+          to: hardcoded(identity),
+          selector: hardcoded(hash.getSelectorFromName("get_verifier_data")),
+          calldata: [
+            reference(1, 0),
+            hardcoded(shortString.encodeShortString("nft_pp_contract")),
+            hardcoded(contracts["verifier_pfp"] as string),
+            hardcoded("0"),
+          ],
+        },
+        {
+          to: hardcoded(identity),
+          selector: hardcoded(
+            hash.getSelectorFromName("get_extended_verifier_data")
+          ),
+          calldata: [
+            reference(1, 0),
+            hardcoded(shortString.encodeShortString("nft_pp_id")),
+            hardcoded("2"),
+            hardcoded(contracts["verifier_pfp"] as string),
+            hardcoded("0"),
+          ],
+        },
+        {
+          to: reference(6, 0),
+          selector: hardcoded(hash.getSelectorFromName("tokenURI")),
+          calldata: [reference(7, 0), reference(7, 1)],
+        },
+      ],
+    ]);
+
+    if (Array.isArray(data)) {
+      const twitter =
+        data[2][0] !== BigInt(0) ? data[2][0].toString() : undefined;
+      const github =
+        data[3][0] !== BigInt(0) ? data[3][0].toString() : undefined;
+      const discord =
+        data[4][0] !== BigInt(0) ? data[4][0].toString() : undefined;
+      const proofOfPersonhood = data[5][0] === BigInt(1) ? true : false;
+
+      let profilePicture = "";
+      data[8].shift();
+      data[8].map((elem: any) => {
+        profilePicture += String.fromCharCode(Number(elem));
+      });
+
+      return {
+        name,
+        twitter,
+        github,
+        discord,
+        proofOfPersonhood,
+        profilePicture,
+      };
+    } else {
+      throw new Error("Error while fetching data");
+    }
+  };
+}
+
+const hardcoded = (arg: string | number) => {
+  return new CairoCustomEnum({
+    Hardcoded: arg,
+  });
+};
+
+const reference = (call: number, pos: number) => {
+  return new CairoCustomEnum({
+    Reference: cairo.tuple(call, pos),
+  });
+};
+
+const arrayReference = (call: number, pos: number) => {
+  return new CairoCustomEnum({
+    ArrayReference: cairo.tuple(call, pos),
+  });
+};
+
+const StarknetIdcontracts: Record<string, Record<string, string>> = {
+  goerli: {
+    naming: "0x3bab268e932d2cecd1946f100ae67ce3dff9fd234119ea2f6da57d16d29fce",
+    identity:
+      "0x783a9097b26eae0586373b2ce0ed3529ddc44069d1e0fbc4f66d42b69d6850d",
+    verifier:
+      "0x019e5204152a72891bf8cd0bed8f03593fdb29ceacd14fca587be5d9fcf87c0e",
+    verifier_pop:
+      "0x03528caf090179e337931ee669a5b0214041e1bae30d460ff07d2cea2c7a9106",
+    verifier_pfp:
+      "0x03cac3228b434259734ee0e4ff445f642206ea11adace7e4f45edd2596748698",
+    multicall:
+      "0x6420d69f38880b5b428ae1a834ea004e0726be4847c40ee23754823717eaf60",
+  },
+  mainnet: {
+    naming: "0x6ac597f8116f886fa1c97a23fa4e08299975ecaf6b598873ca6792b9bbfb678",
+    identity:
+      "0x05dbdedc203e92749e2e746e2d40a768d966bd243df04a6b712e222bc040a9af",
+    verifier:
+      "0x07d14dfd8ee95b41fce179170d88ba1f0d5a512e13aeb232f19cfeec0a88f8bf",
+    verifier_pop:
+      "0x0293eb2ba9862f762bd3036586d5755a782bd22e6f5028320f1d0405fd47bff4",
+    verifier_pfp:
+      "0x070aaa20ec4a46da57c932d9fd89ca5e6bb9ca3188d3df361a32306aff7d59c7",
+    multicall: "", // todo: deploy on mainnet and add address
+  },
+};
+
+const multicallABI = [
+  {
+    type: "impl",
+    name: "ComposableMulticallImpl",
+    interface_name: "composable_multicall::IComposableMulticall",
+  },
+  {
+    type: "enum",
+    name: "composable_multicall::DynamicFelt",
+    variants: [
+      { name: "Hardcoded", type: "core::felt252" },
+      { name: "Reference", type: "(core::integer::u32, core::integer::u32)" },
+    ],
+  },
+  {
+    type: "enum",
+    name: "composable_multicall::DynamicCalldata",
+    variants: [
+      { name: "Hardcoded", type: "core::felt252" },
+      { name: "Reference", type: "(core::integer::u32, core::integer::u32)" },
+      {
+        name: "ArrayReference",
+        type: "(core::integer::u32, core::integer::u32)",
+      },
+    ],
+  },
+  {
+    type: "struct",
+    name: "composable_multicall::DynamicCall",
+    members: [
+      { name: "to", type: "composable_multicall::DynamicFelt" },
+      { name: "selector", type: "composable_multicall::DynamicFelt" },
+      {
+        name: "calldata",
+        type: "core::array::Array::<composable_multicall::DynamicCalldata>",
+      },
+    ],
+  },
+  {
+    type: "struct",
+    name: "core::array::Span::<core::felt252>",
+    members: [
+      { name: "snapshot", type: "@core::array::Array::<core::felt252>" },
+    ],
+  },
+  {
+    type: "interface",
+    name: "composable_multicall::IComposableMulticall",
+    items: [
+      {
+        type: "function",
+        name: "aggregate",
+        inputs: [
+          {
+            name: "calls",
+            type: "core::array::Array::<composable_multicall::DynamicCall>",
+          },
+        ],
+        outputs: [
+          { type: "core::array::Array::<core::array::Span::<core::felt252>>" },
+        ],
+        state_mutability: "view",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "composable_multicall::contract::ComposableMulticall::Event",
+    kind: "enum",
+    variants: [],
+  },
+];

--- a/packages/core/src/hooks/useStarkProfile.ts
+++ b/packages/core/src/hooks/useStarkProfile.ts
@@ -23,6 +23,8 @@ export type StarkProfileArgs = UseQueryProps<
 > & {
   /** Account address. */
   address?: string;
+  /** Get Starknet ID identicons if no profile picture is set */
+  identicons?: boolean;
   /** Naming contract to use. */
   namingContract?: string;
   /** Identity contract to use. */
@@ -80,12 +82,12 @@ export type useStarkProfileResult = UseQueryResult<
  * ```
  *
  *  @example
- * This example shows how to get the stark profile of an address specifying a
+ * This example shows how to get the stark profile of an address enabling identicons and specifying a
  * different naming and identity contract addresses
  * ```tsx
  * function Component() {
  *   const address = '0x061b6c0a78f9edf13cea17b50719f3344533fadd470b8cb29c2b4318014f52d3'
- *   const { data, isLoading, isError } = useStarkProfile({ address, namingContract: '0x1234', identityContract: '0x5678' })
+ *   const { data, isLoading, isError } = useStarkProfile({ address, identicons: true, namingContract: '0x1234', identityContract: '0x5678' })
  *
  *   if (isLoading) return <span>Loading...</span>
  *   if (isError) return <span>Error fetching profile...</span>
@@ -103,6 +105,7 @@ export type useStarkProfileResult = UseQueryResult<
  */
 export function useStarkProfile({
   address,
+  identicons = false,
   namingContract,
   identityContract,
   enabled: enabled_ = true,
@@ -124,6 +127,7 @@ export function useStarkProfile({
     queryKey: queryKey({ address, namingContract, identityContract }),
     queryFn: queryFn({
       address,
+      identicons,
       namingContract,
       provider,
       network: chain.network,
@@ -151,6 +155,7 @@ function queryKey({
 
 function queryFn({
   address,
+  identicons,
   namingContract,
   identityContract,
   provider,
@@ -285,7 +290,11 @@ function queryFn({
           : undefined;
 
       // extract nft_image from profile data
-      const profilePicture = profile ? await fetchImageUrl(profile) : undefined;
+      const profilePicture = profile
+        ? await fetchImageUrl(profile)
+        : identicons
+        ? `https://starknet.id/api/identicons/${data[1][0].toString()}`
+        : undefined;
 
       return {
         name,

--- a/packages/core/src/hooks/useStarkProfile.ts
+++ b/packages/core/src/hooks/useStarkProfile.ts
@@ -82,7 +82,7 @@ export type useStarkProfileResult = UseQueryResult<
  * ```tsx
  * function Component() {
  *   const address = '0x061b6c0a78f9edf13cea17b50719f3344533fadd470b8cb29c2b4318014f52d3'
- *   const { data, isLoading, isError } = useStarkName({ address, namingContract: '0x1234', identityContract: '0x5678' })
+ *   const { data, isLoading, isError } = useStarkProfile({ address, namingContract: '0x1234', identityContract: '0x5678' })
  *
  *   if (isLoading) return <span>Loading...</span>
  *   if (isError) return <span>Error fetching profile...</span>

--- a/website/components/demos/starknetid.tsx
+++ b/website/components/demos/starknetid.tsx
@@ -1,7 +1,11 @@
 "use client";
 import React, { useState } from "react";
 
-import { useStarkName, useStarkAddress } from "@starknet-react/core";
+import {
+  useStarkName,
+  useStarkAddress,
+  useStarkProfile,
+} from "@starknet-react/core";
 import { AlertCircle, Loader2 } from "lucide-react";
 import { useDebounce } from "usehooks-ts";
 
@@ -31,9 +35,10 @@ function Inner() {
     <div className="w-full">
       <div className="max-w-[600px] mx-auto">
         <Tabs defaultValue="address" className="w-full">
-          <TabsList className="grid w-full grid-cols-2">
+          <TabsList className="grid w-full grid-cols-3">
             <TabsTrigger value="address">Lookup address</TabsTrigger>
             <TabsTrigger value="name">Lookup name</TabsTrigger>
+            <TabsTrigger value="profile">Lookup profile</TabsTrigger>
           </TabsList>
           <TabsContent value="address">
             <Card>
@@ -58,6 +63,19 @@ function Inner() {
               </CardHeader>
               <CardContent>
                 <LookupName />
+              </CardContent>
+            </Card>
+          </TabsContent>
+          <TabsContent value="profile">
+            <Card>
+              <CardHeader>
+                <CardTitle>Lookup Starknet profile</CardTitle>
+                <CardDescription>
+                  Lookup a Starknet ID profile by its Starknet address.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <LookupProfile />
               </CardContent>
             </Card>
           </TabsContent>
@@ -128,6 +146,54 @@ function LookupName() {
           <Loader2 className="h-4 w-4 mr-2 animate-spin" />
         ) : (
           <p>Name: {data}</p>
+        )}
+      </div>
+      {error ? (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>{(error as Error).message}</AlertDescription>
+        </Alert>
+      ) : null}
+    </div>
+  );
+}
+
+function LookupProfile() {
+  const [address, setAddress] = useState<string>("");
+
+  const debounceAddress = useDebounce(address, 500);
+
+  const { data, error, isLoading } = useStarkProfile({
+    address: debounceAddress,
+  });
+
+  console.log("data", data);
+  console.log("error", error);
+
+  return (
+    <div className="space-y-2">
+      <div className="space-y-1">
+        <Label htmlFor="address">Address</Label>
+        <Input
+          id="address"
+          placeholder="0x0508...8775"
+          value={address}
+          onChange={(evt) => setAddress(evt.target.value)}
+        />
+      </div>
+      <div className="space-y-1">
+        {isLoading ? (
+          <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+        ) : (
+          <>
+            <p>Name: {data?.name}</p>
+            <p>Discord id: {data?.discord}</p>
+            <p>Twitter id: {data?.twitter}</p>
+            <p>Github id: {data?.github}</p>
+            <p>Proof of personhood verification: {data?.proofOfPersonhood}</p>
+            <p>Profile picture metadata uri : {data?.profilePicture}</p>
+          </>
         )}
       </div>
       {error ? (

--- a/website/components/demos/starknetid.tsx
+++ b/website/components/demos/starknetid.tsx
@@ -168,7 +168,7 @@ function LookupProfile() {
 
   const { data, error, isLoading } = useStarkProfile({
     address: debounceAddress,
-    identicons: true,
+    useDefaultPfp: true,
   });
 
   return (

--- a/website/components/demos/starknetid.tsx
+++ b/website/components/demos/starknetid.tsx
@@ -194,7 +194,8 @@ function LookupProfile() {
               Proof of personhood verification:{" "}
               {data?.proofOfPersonhood ? "true" : "-"}
             </p>
-            <p>Profile picture metadata uri : {data?.profilePicture}</p>
+            <p>Profile picture metadata uri : {data?.profile}</p>
+            <p>Profile picture uri : {data?.profilePicture}</p>
           </>
         )}
       </div>

--- a/website/components/demos/starknetid.tsx
+++ b/website/components/demos/starknetid.tsx
@@ -168,6 +168,7 @@ function LookupProfile() {
 
   const { data, error, isLoading } = useStarkProfile({
     address: debounceAddress,
+    identicons: true,
   });
 
   return (

--- a/website/components/demos/starknetid.tsx
+++ b/website/components/demos/starknetid.tsx
@@ -160,16 +160,15 @@ function LookupName() {
 }
 
 function LookupProfile() {
-  const [address, setAddress] = useState<string>("");
+  const [address, setAddress] = useState<string>(
+    "0x00a00373a00352aa367058555149b573322910d54fcdf3a926e3e56d0dcb4b0c"
+  );
 
   const debounceAddress = useDebounce(address, 500);
 
   const { data, error, isLoading } = useStarkProfile({
     address: debounceAddress,
   });
-
-  console.log("data", data);
-  console.log("error", error);
 
   return (
     <div className="space-y-2">
@@ -188,10 +187,13 @@ function LookupProfile() {
         ) : (
           <>
             <p>Name: {data?.name}</p>
-            <p>Discord id: {data?.discord}</p>
-            <p>Twitter id: {data?.twitter}</p>
-            <p>Github id: {data?.github}</p>
-            <p>Proof of personhood verification: {data?.proofOfPersonhood}</p>
+            <p>Discord id: {data?.discord ?? "-"}</p>
+            <p>Twitter id: {data?.twitter ?? "-"}</p>
+            <p>Github id: {data?.github ?? "-"}</p>
+            <p>
+              Proof of personhood verification:{" "}
+              {data?.proofOfPersonhood ? "true" : "-"}
+            </p>
             <p>Profile picture metadata uri : {data?.profilePicture}</p>
           </>
         )}

--- a/website/content/demos/starknetid.mdx
+++ b/website/content/demos/starknetid.mdx
@@ -61,7 +61,7 @@ function MyComponent() {
   const debounceAddress = useDebounce(address, 500);
 
   const { data, error, isLoading } = useStarkName({
-    address: debounceAddress
+    address: debounceAddress,
   });
 
   return (
@@ -80,6 +80,53 @@ function MyComponent() {
           <Loader2 className="h-4 w-4 mr-2 animate-spin" />
         ) : (
           <p>Name: {data}</p>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+## Lookup Stark profile
+
+Use the `useStarkProfile` hook to lookup the Starknet.ID associated data with a Starknet
+address.
+
+```tsx lookup-stark-profile.tsx
+import { useStarkProfile } from "@starknet-react/core";
+
+function MyComponent() {
+  const [address, setAddress] = useState<string>("");
+
+  const debounceAddress = useDebounce(address, 500);
+
+  const { data, error, isLoading } = useStarkProfile({
+    address: debounceAddress,
+  });
+
+  return (
+    <div className="space-y-2">
+      <div className="space-y-1">
+        <Label htmlFor="address">Address</Label>
+        <Input
+          id="address"
+          placeholder="0x0508...8775"
+          value={address}
+          onChange={(evt) => setAddress(evt.target.value)}
+        />
+      </div>
+      <div className="space-y-1">
+        {isLoading ? (
+          <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+        ) : (
+          <>
+            <p>Name: {data?.name}</p>
+            <p>Discord id: {data?.discord}</p>
+            <p>Twitter id: {data?.twitter}</p>
+            <p>Github id: {data?.github}</p>
+            <p>Proof of personhood verification: {data?.proofOfPersonhood}</p>
+            <p>Profile picture metadata uri : {data?.profilePicture}</p>
+          </>
         )}
       </div>
     </div>

--- a/website/content/demos/starknetid.mdx
+++ b/website/content/demos/starknetid.mdx
@@ -129,7 +129,8 @@ function MyComponent() {
             <p>Twitter id: {data?.twitter}</p>
             <p>Github id: {data?.github}</p>
             <p>Proof of personhood verification: {data?.proofOfPersonhood}</p>
-            <p>Profile picture metadata uri : {data?.profilePicture}</p>
+            <p>Profile picture metadata uri : {data?.profile}</p>
+            <p>Profile picture uri : {data?.profilePicture}</p>
           </>
         )}
       </div>

--- a/website/content/demos/starknetid.mdx
+++ b/website/content/demos/starknetid.mdx
@@ -57,7 +57,9 @@ address.
 import { useStarkAddress } from "@starknet-react/core";
 
 function MyComponent() {
-  const [address, setAddress] = useState<string>("");
+  const [address, setAddress] = useState<string>(
+    "0x00a00373a00352aa367058555149b573322910d54fcdf3a926e3e56d0dcb4b0c"
+  );
   const debounceAddress = useDebounce(address, 500);
 
   const { data, error, isLoading } = useStarkName({
@@ -96,7 +98,9 @@ address.
 import { useStarkProfile } from "@starknet-react/core";
 
 function MyComponent() {
-  const [address, setAddress] = useState<string>("");
+  const [address, setAddress] = useState<string>(
+    "0x00a00373a00352aa367058555149b573322910d54fcdf3a926e3e56d0dcb4b0c"
+  );
 
   const debounceAddress = useDebounce(address, 500);
 

--- a/website/content/hooks/query/useStarkProfile.mdx
+++ b/website/content/hooks/query/useStarkProfile.mdx
@@ -33,6 +33,8 @@ function Component() {
 
 - **address?**`: string`
   - Account address.
+- **identicons?**`: boolean`
+  - Enable identicons if not profile picture is set.
 - **namingContract?**`: string`
   - Naming contract to use.
 - **identityContract?**`: string`

--- a/website/content/hooks/query/useStarkProfile.mdx
+++ b/website/content/hooks/query/useStarkProfile.mdx
@@ -40,9 +40,10 @@ function Component() {
 
 ## Returns
 
-- **data?**`: { name: string, profilePicture: string, twitter: string, github: string, discord: string, proofOfPersonhood: boolean }`
+- **data?**`: { name: string, profile: string, profilePicture: string, twitter: string, github: string, discord: string, proofOfPersonhood: boolean }`
   - the Stark name.
   - the metadata uri of the profile picture.
+  - the uri of the profile picture.
   - the twitter id.
   - the github id.
   - the discord id.

--- a/website/content/hooks/query/useStarkProfile.mdx
+++ b/website/content/hooks/query/useStarkProfile.mdx
@@ -23,7 +23,8 @@ function Component() {
       <p>Twitter id: {data?.twitter}</p>
       <p>Github id: {data?.github}</p>
       <p>Proof of personhood verification: {data?.proofOfPersonhood}</p>
-      <p>Profile picture metadata : {data?.profilePicture}</p>
+      <p>Profile picture metadata uri : {data?.profile}</p>
+      <p>Profile picture uri : {data?.profilePicture}</p>
     </>
   );
 }

--- a/website/content/hooks/query/useStarkProfile.mdx
+++ b/website/content/hooks/query/useStarkProfile.mdx
@@ -1,0 +1,49 @@
+---
+title: useStarkProfile
+priority: 196
+hookType: query
+---
+
+Get the Stark profile associated with an address.
+
+## Usage
+
+```tsx
+function Component() {
+  const address =
+    "0x061b6c0a78f9edf13cea17b50719f3344533fadd470b8cb29c2b4318014f52d3";
+  const { data, isLoading, isError } = useStarkProfile({ address });
+
+  if (isLoading) return <span>Loading...</span>;
+  if (isError) return <span>Error fetching profile...</span>;
+  return (
+    <>
+      <p>Name: {data?.name}</p>
+      <p>Discord id: {data?.discord}</p>
+      <p>Twitter id: {data?.twitter}</p>
+      <p>Github id: {data?.github}</p>
+      <p>Proof of personhood verification: {data?.proofOfPersonhood}</p>
+      <p>Profile picture metadata : {data?.profilePicture}</p>
+    </>
+  );
+}
+```
+
+## Options
+
+- **address?**`: string`
+  - Account address.
+- **namingContract?**`: string`
+  - Naming contract to use.
+- **identityContract?**`: string`
+  - Identity contract to use.
+
+## Returns
+
+- **data?**`: { name: string, profilePicture: string, twitter: string, github: string, discord: string, proofOfPersonhood: boolean }`
+  - the Stark name.
+  - the metadata uri of the profile picture.
+  - the twitter id.
+  - the github id.
+  - the discord id.
+  - the proof of personhood verification.

--- a/website/content/hooks/query/useStarkProfile.mdx
+++ b/website/content/hooks/query/useStarkProfile.mdx
@@ -34,8 +34,8 @@ function Component() {
 
 - **address?**`: string`
   - Account address.
-- **identicons?**`: boolean`
-  - Enable identicons if not profile picture is set.
+- **useDefaultPfp?**`: boolean`
+  - Get starknet ID default pfp url if not profile picture is set.
 - **namingContract?**`: string`
   - Naming contract to use.
 - **identityContract?**`: string`


### PR DESCRIPTION
This PR introduce a new hook `useStarkProfile` which retrieves a user starkname and all data he may have written on his starknet id :  his profile picture metadata, his social media verification (twitter id, github id, discord id), and if the user has done his proof of personhood verification. 