### PR TITLE
api: export StarknetContext API

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@starknet-react/core": "^2.2.5",
+    "@starknet-react/core": "workspace:^",
     "get-starknet": "^3.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@starknet-react/core": "workspace:^",
+    "@starknet-react/core": "^2.2.5",
     "get-starknet": "^3.0.1"
   }
 }

--- a/packages/core/src/context/account.tsx
+++ b/packages/core/src/context/account.tsx
@@ -11,6 +11,8 @@ export function useStarknetAccount() {
   return { account };
 }
 
+export { StarknetContext } from "./starknet";
+
 export function AccountProvider({
   account,
   children,

--- a/packages/core/src/context/starknet.tsx
+++ b/packages/core/src/context/starknet.tsx
@@ -39,7 +39,7 @@ export interface StarknetState {
   error?: Error;
 }
 
-const StarknetContext = createContext<StarknetState | undefined>(undefined);
+export const StarknetContext = createContext<StarknetState | undefined>(undefined);
 
 /**
  * Returns the current Starknet context state.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@starknet-react/core':
-        specifier: ^2.2.5
+        specifier: workspace:^
         version: link:packages/core
       get-starknet:
         specifier: ^3.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,11 +1,15 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
     dependencies:
       '@starknet-react/core':
-        specifier: workspace:^
+        specifier: ^2.2.5
         version: link:packages/core
       get-starknet:
         specifier: ^3.0.1
@@ -8227,7 +8231,3 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: false
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
This exposes the StarknetContext API so that the context can be used by other components that requires the StarknetContext API

Closes #401 