### PR TITLE
Fix usebalance

### DIFF
--- a/packages/core/src/hooks/useBalance.ts
+++ b/packages/core/src/hooks/useBalance.ts
@@ -137,7 +137,9 @@ function queryFn({
       symbolPromise,
     ]);
 
-    const formatted = (balanceOf / BigInt(10 ** decimals)).toString();
+    const formatted = (
+      Number(balanceOf * 10_000n / BigInt(10 ** decimals)) / 10_000
+    ).toString();
 
     return {
       value: balanceOf,

--- a/packages/core/src/hooks/useBalance.ts
+++ b/packages/core/src/hooks/useBalance.ts
@@ -137,7 +137,7 @@ function queryFn({
       symbolPromise,
     ]);
 
-    const formatted = (Number(balanceOf) / 10 ** decimals).toString();
+    const formatted = (balanceOf / BigInt(10 ** decimals)).toString();
 
     return {
       value: balanceOf,


### PR DESCRIPTION
(closed #407 )

-should avoid weird js rounding error like this one 😢 :
`(25000000000000000000000000000 / 10**18).toString()  ---> '24999999999.999996'`
-avoid overflow if balanceOf too big for number

-4 decimals precision
