### PR TITLE
Fix Unhandled Runtime Error on contract read page

### DIFF
--- a/website/components/demos/contract-read.tsx
+++ b/website/components/demos/contract-read.tsx
@@ -44,6 +44,14 @@ function ContractRead() {
       blockIdentifier === "latest" ? BlockTag.latest : BlockTag.pending,
   });
 
+  // Cast bigint into string to avoid "TypeError: Do not know how to serialize a BigInt"
+  // See https://github.com/GoogleChromeLabs/jsbi/issues/30#issuecomment-521460510
+  const callResult = JSON.stringify(data, (_key, value) =>
+    typeof value === 'bigint'
+        ? value.toString()
+        : value
+  );
+
   return (
     <Card className="max-w-[400px] mx-auto">
       <CardHeader>
@@ -74,7 +82,7 @@ function ContractRead() {
         </div>
         <div className="space-y-1">
           <Label>Call result</Label>
-          <p>{JSON.stringify(data)}</p>
+          <p>{callResult}</p>
         </div>
         <div className="space-y-1">
           <Button onClick={() => refetch()}>Refetch data</Button>


### PR DESCRIPTION
# Description 

Due to the serialization of bigint. 

# Result 

<img width="238" alt="image" src="https://github.com/apibara/starknet-react/assets/23191482/264d34a6-d8cb-4b26-a034-1e68ba7f0928">

# Test

https://deploy-preview-417--starknet-react.netlify.app/demos/contract-read

Closes #416