### PR TITLE
fix: useStarkProfile to work with base64 tokenURI

### DIFF
--- a/.changeset/stale-numbers-juggle.md
+++ b/.changeset/stale-numbers-juggle.md
@@ -1,0 +1,5 @@
+---
+"@starknet-react/core": minor
+---
+
+fix: useStarkProfile to work with base64 tokenURI

--- a/packages/core/src/hooks/useStarkProfile.ts
+++ b/packages/core/src/hooks/useStarkProfile.ts
@@ -120,7 +120,7 @@ export function useStarkProfile({
 
   const enabled = useMemo(
     () => Boolean(enabled_ && address),
-    [enabled_, address],
+    [enabled_, address]
   );
 
   return useQuery({
@@ -251,7 +251,7 @@ function queryFn({
           execution: staticExecution(),
           to: hardcoded(identity),
           selector: hardcoded(
-            hash.getSelectorFromName("get_extended_verifier_data"),
+            hash.getSelectorFromName("get_extended_verifier_data")
           ),
           calldata: [
             reference(1, 0),
@@ -284,14 +284,16 @@ function queryFn({
           ? data[8]
               .slice(1)
               .map((val: BigInt) =>
-                shortString.decodeShortString(val.toString()),
+                shortString.decodeShortString(val.toString())
               )
               .join("")
           : undefined;
 
       // extract nft_image from profile data
       const profilePicture = profile
-        ? await fetchImageUrl(profile)
+        ? profile.includes("base64")
+          ? JSON.parse(atob(profile.split(",")[1].slice(0, -1))).image
+          : await fetchImageUrl(profile)
         : useDefaultPfp
         ? `https://starknet.id/api/identicons/${data[1][0].toString()}`
         : undefined;


### PR DESCRIPTION
This PR fixes a bug in `useStarkProfile` which currently returns an error for Blobbert NFTs that are set as profile picture. 