### PR TITLE
feat: wallet connection using starknet v6

### DIFF
--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -186,7 +186,7 @@ export class InjectedConnector extends Connector {
 
   private ensureWallet() {
     const installed = getAvailableWallets(globalThis);
-    const wallet = installed.filter((w) => w.id === this._options.id)[0];
+    const [wallet] = installed.filter((w) => w.id === this._options.id);
     if (wallet) {
       this._wallet = wallet;
     }

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -81,11 +81,15 @@ export class InjectedConnector extends Connector {
       throw new ConnectorNotConnectedError();
     }
 
-    const chainIdHex = await this._wallet.request({
-      type: "wallet_requestChainId",
-    });
-    const chainId = BigInt(chainIdHex);
-    return chainId;
+    try {
+      const chainIdHex = await this._wallet.request({
+        type: "wallet_requestChainId",
+      });
+      const chainId = BigInt(chainIdHex);
+      return chainId;
+    } catch {
+      throw new ConnectorNotFoundError();
+    }
   }
 
   async ready(): Promise<boolean> {
@@ -181,6 +185,7 @@ export class InjectedConnector extends Connector {
       throw new ConnectorNotConnectedError();
     }
 
+    // wallet_requestAccounts should be used with silent_mode: true when the API works again
     return temp.account as AccountInterface;
   }
 


### PR DESCRIPTION
Update `InjectedConnector` class to work with starknet.js V6:

- fix: `chainId` method
- fix: `connect` method
- fix: `account` method 

/!\ temporary solution due to `StarknetWindowObject` not being correctly typed. Most of the properties are missing yet those properties does exist in the window object meaning they are here but typescript prevent us from accessing it.

In order to have this properly made we need to wait for `starknet-types` to be updated with a stable version.

/!\ On top of that `StarknetWindowObject` does have the property account filled only when we do the whole process of connection with a wallet, otherwise it's not persisted, most possibly due to the library itself being unstable.