### PR TITLE
fix: move the default query client to outside of the component

### DIFF
--- a/.changeset/shy-planets-poke.md
+++ b/.changeset/shy-planets-poke.md
@@ -1,0 +1,5 @@
+---
+"@starknet-react/core": patch
+---
+
+Move the default query client to outside of the Provider component

--- a/packages/core/src/context/starknet.tsx
+++ b/packages/core/src/context/starknet.tsx
@@ -17,6 +17,8 @@ import { ChainProviderFactory } from "~/providers";
 import { ExplorerFactory } from "~/explorers/";
 import { AccountProvider } from "./account";
 
+const defaultQueryClient = new QueryClient();
+
 /** State of the Starknet context. */
 export interface StarknetState {
   /** Connected connector. */
@@ -317,7 +319,7 @@ export function StarknetProvider({
   });
 
   return (
-    <QueryClientProvider client={queryClient ?? new QueryClient()}>
+    <QueryClientProvider client={queryClient ?? defaultQueryClient}>
       <StarknetContext.Provider value={state}>
         <AccountProvider account={account}>{children}</AccountProvider>
       </StarknetContext.Provider>


### PR DESCRIPTION
The current implementation of the query client within the function component leads to the creation of a new query client on each re-render. Consequently, this behavior results in the loss of data and caches associated with the query client.

This PR addresses the issue by relocating the default query client outside of the function component. By doing so, we ensure that the query client persists across re-renders, maintaining data integrity and cache consistency.

While it's possible to resolve this issue by directly providing the query client to the Provider on usage, this caused us some time to locate and fix the issue, hence the decision to refactor the implementation.