### PR TITLE
Live typescript

### DIFF
--- a/packages/chains/package.json
+++ b/packages/chains/package.json
@@ -2,15 +2,31 @@
   "name": "@starknet-react/chains",
   "version": "0.1.7",
   "license": "MIT",
+  "repository": "apibara/starknet-react",
+  "homepage": "https://www.starknet-react.com/",
+  "keywords": [
+    "starknet",
+    "ethereum",
+    "l2"
+  ],
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
-    }
+  "main": "./src/index.ts",
+  "exports": "./src/index.ts",
+  "publishConfig": {
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
+      }
+    },
+    "files": [
+      "dist",
+      "src",
+      "README.md"
+    ]
   },
   "scripts": {
     "build": "tsup",
@@ -20,18 +36,6 @@
     "format:check": "biome format .",
     "format": "biome format . --write"
   },
-  "files": [
-    "dist",
-    "src",
-    "README.md"
-  ],
-  "repository": "apibara/starknet-react",
-  "homepage": "https://apibara.github.io/starknet-react/",
-  "keywords": [
-    "starknet",
-    "ethereum",
-    "l2"
-  ],
   "devDependencies": {
     "@starknet-react/typescript-config": "workspace:*",
     "rimraf": "^4.1.2",

--- a/packages/chains/tsconfig.json
+++ b/packages/chains/tsconfig.json
@@ -1,11 +1,7 @@
 {
 	"extends": "@starknet-react/typescript-config/react-library.json",
 	"compilerOptions": {
-		"outDir": "dist",
-		"baseUrl": ".",
-		"paths": {
-			"~/*": ["src/*"]
-		}
+		"outDir": "dist"
 	},
 	"include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,15 +2,31 @@
   "name": "@starknet-react/core",
   "version": "0.1.7",
   "license": "MIT",
+  "repository": "apibara/starknet-react",
+  "homepage": "https://www.starknet-react.com",
+  "keywords": [
+    "starknet",
+    "ethereum",
+    "l2"
+  ],
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
-    }
+  "main": "./src/index.ts",
+  "exports": "./src/index.ts",
+  "publishConfig": {
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
+      }
+    },
+    "files": [
+      "dist",
+      "src",
+      "README.md"
+    ]
   },
   "scripts": {
     "build": "tsup",
@@ -21,18 +37,6 @@
     "format:check": "biome format .",
     "format": "biome format . --write"
   },
-  "files": [
-    "dist",
-    "src",
-    "README.md"
-  ],
-  "repository": "apibara/starknet-react",
-  "homepage": "https://apibara.github.io/starknet-react/",
-  "keywords": [
-    "starknet",
-    "ethereum",
-    "l2"
-  ],
   "peerDependencies": {
     "get-starknet-core": "^4.0.0-next.5",
     "react": "^18.0",

--- a/packages/core/src/context/starknet.tsx
+++ b/packages/core/src/context/starknet.tsx
@@ -10,11 +10,12 @@ import React, {
 } from "react";
 import { constants, AccountInterface, ProviderInterface } from "starknet";
 
-import { Connector } from "~/connectors";
-import { ConnectorData } from "~/connectors/base";
-import { ConnectorNotFoundError } from "~/errors";
-import { ExplorerFactory } from "~/explorers/";
-import { ChainProviderFactory } from "~/providers";
+import { Connector } from "../connectors";
+import { ConnectorData } from "../connectors/base";
+import { ConnectorNotFoundError } from "../errors";
+import { ExplorerFactory } from "../explorers/";
+import { ChainProviderFactory } from "../providers";
+
 import { AccountProvider } from "./account";
 
 /** State of the Starknet context. */

--- a/packages/core/src/hooks/useAccount.ts
+++ b/packages/core/src/hooks/useAccount.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useState } from "react";
 import { AccountInterface } from "starknet";
 
-import { Connector } from "~/connectors";
-import { useStarknetAccount } from "~/context/account";
+import { Connector } from "../connectors";
+import { useStarknetAccount } from "../context/account";
 
 import { useConnect } from "./useConnect";
 import { useProvider } from "./useProvider";

--- a/packages/core/src/hooks/useBalance.ts
+++ b/packages/core/src/hooks/useBalance.ts
@@ -2,7 +2,7 @@ import { Chain } from "@starknet-react/chains";
 import { useMemo } from "react";
 import { BlockNumber, BlockTag, CallOptions, num, shortString } from "starknet";
 
-import { UseQueryProps, UseQueryResult, useQuery } from "~/query";
+import { UseQueryProps, UseQueryResult, useQuery } from "../query";
 
 import { StarknetTypedContract, useContract } from "./useContract";
 import { useInvalidateOnBlock } from "./useInvalidateOnBlock";

--- a/packages/core/src/hooks/useBlock.ts
+++ b/packages/core/src/hooks/useBlock.ts
@@ -5,8 +5,8 @@ import {
   ProviderInterface,
 } from "starknet";
 
-import { useStarknet } from "~/context/starknet";
-import { UseQueryProps, UseQueryResult, useQuery } from "~/query";
+import { useStarknet } from "../context/starknet";
+import { UseQueryProps, UseQueryResult, useQuery } from "../query";
 
 /** Arguments for `useBlock`. */
 export type UseBlockProps = UseQueryProps<

--- a/packages/core/src/hooks/useBlockNumber.ts
+++ b/packages/core/src/hooks/useBlockNumber.ts
@@ -1,7 +1,7 @@
 import { BlockNumber, BlockTag, ProviderInterface } from "starknet";
 
-import { useStarknet } from "~/context/starknet";
-import { UseQueryProps, UseQueryResult, useQuery } from "~/query";
+import { useStarknet } from "../context/starknet";
+import { UseQueryProps, UseQueryResult, useQuery } from "../query";
 
 /** Arguments for `useBlockNumber`. */
 export type UseBlockNumberProps = UseQueryProps<

--- a/packages/core/src/hooks/useCall.ts
+++ b/packages/core/src/hooks/useCall.ts
@@ -9,7 +9,7 @@ import {
   Result,
 } from "starknet";
 
-import { UseQueryProps, UseQueryResult, useQuery } from "~/query";
+import { UseQueryProps, UseQueryResult, useQuery } from "../query";
 import { useContract } from "./useContract";
 import { useInvalidateOnBlock } from "./useInvalidateOnBlock";
 import { useNetwork } from "./useNetwork";

--- a/packages/core/src/hooks/useConnect.ts
+++ b/packages/core/src/hooks/useConnect.ts
@@ -1,8 +1,8 @@
-import { useStarknet } from "~/context/starknet";
-
 import { useCallback } from "react";
-import { Connector } from "~/connectors/base";
-import { UseMutationProps, UseMutationResult, useMutation } from "~/query";
+
+import { Connector } from "../connectors/base";
+import { useStarknet } from "../context/starknet";
+import { UseMutationProps, UseMutationResult, useMutation } from "../query";
 
 export type ConnectVariables = { connector?: Connector };
 

--- a/packages/core/src/hooks/useContract.ts
+++ b/packages/core/src/hooks/useContract.ts
@@ -10,7 +10,7 @@ import {
 import { useMemo } from "react";
 import { Call, CallOptions, Contract, ProviderInterface } from "starknet";
 
-import { useStarknet } from "~/context/starknet";
+import { useStarknet } from "../context/starknet";
 
 // did this because "Omit" wont work directly over an abstract class
 type Contract_ = {

--- a/packages/core/src/hooks/useDeployAccount.ts
+++ b/packages/core/src/hooks/useDeployAccount.ts
@@ -5,7 +5,8 @@ import {
   InvocationsDetails,
   RawArgs,
 } from "starknet";
-import { UseMutationProps, UseMutationResult, useMutation } from "~/query";
+
+import { UseMutationProps, UseMutationResult, useMutation } from "../query";
 
 import { useAccount } from "./useAccount";
 

--- a/packages/core/src/hooks/useDisconnect.ts
+++ b/packages/core/src/hooks/useDisconnect.ts
@@ -1,6 +1,5 @@
-import { useStarknet } from "~/context/starknet";
-
-import { UseMutationProps, UseMutationResult, useMutation } from "~/query";
+import { useStarknet } from "../context/starknet";
+import { UseMutationProps, UseMutationResult, useMutation } from "../query";
 
 type MutationResult = UseMutationResult<void, unknown, void>;
 

--- a/packages/core/src/hooks/useEstimateFees.ts
+++ b/packages/core/src/hooks/useEstimateFees.ts
@@ -6,7 +6,7 @@ import {
   EstimateFeeResponse,
 } from "starknet";
 
-import { UseQueryProps, UseQueryResult, useQuery } from "~/query";
+import { UseQueryProps, UseQueryResult, useQuery } from "../query";
 
 import { useAccount } from "./useAccount";
 import { useInvalidateOnBlock } from "./useInvalidateOnBlock";

--- a/packages/core/src/hooks/useExplorer.ts
+++ b/packages/core/src/hooks/useExplorer.ts
@@ -1,5 +1,5 @@
-import { useStarknet } from "~/context/starknet";
-import { Explorer } from "~/explorers";
+import { useStarknet } from "../context/starknet";
+import { Explorer } from "../explorers";
 
 export function useExplorer(): Explorer {
   const { explorer, chain } = useStarknet();

--- a/packages/core/src/hooks/useInvalidateOnBlock.ts
+++ b/packages/core/src/hooks/useInvalidateOnBlock.ts
@@ -1,5 +1,6 @@
 import { QueryKey, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
+
 import { useBlockNumber } from "./useBlockNumber";
 
 /**

--- a/packages/core/src/hooks/useNetwork.ts
+++ b/packages/core/src/hooks/useNetwork.ts
@@ -1,5 +1,6 @@
 import { Chain } from "@starknet-react/chains";
-import { useStarknet } from "~/context/starknet";
+
+import { useStarknet } from "../context/starknet";
 
 /** Value returned from `useNetwork`. */
 export type UseNetworkResult = {

--- a/packages/core/src/hooks/useProvider.ts
+++ b/packages/core/src/hooks/useProvider.ts
@@ -1,6 +1,6 @@
 import { ProviderInterface } from "starknet";
 
-import { useStarknet } from "~/context/starknet";
+import { useStarknet } from "../context/starknet";
 
 /** Value returned from `useProvider`. */
 export interface UseProviderResult {

--- a/packages/core/src/hooks/useReadContract.ts
+++ b/packages/core/src/hooks/useReadContract.ts
@@ -6,7 +6,9 @@ import {
   FunctionRet,
 } from "abi-wan-kanabi/dist/kanabi";
 import { BlockNumber } from "starknet";
-import { UseQueryProps, UseQueryResult } from "~/query";
+
+import { UseQueryProps, UseQueryResult } from "../query";
+
 import { CallQueryKey, UseCallProps, useCall } from "./useCall";
 
 type Result<

--- a/packages/core/src/hooks/useStarkAddress.ts
+++ b/packages/core/src/hooks/useStarkAddress.ts
@@ -1,7 +1,8 @@
 import { useMemo } from "react";
 import { CallData, Provider, ProviderInterface, starknetId } from "starknet";
 
-import { UseQueryProps, UseQueryResult, useQuery } from "~/query";
+import { UseQueryProps, UseQueryResult, useQuery } from "../query";
+
 import { useNetwork } from "./useNetwork";
 import { useProvider } from "./useProvider";
 

--- a/packages/core/src/hooks/useStarkName.ts
+++ b/packages/core/src/hooks/useStarkName.ts
@@ -1,7 +1,8 @@
 import { useMemo } from "react";
 import { Provider, ProviderInterface } from "starknet";
 
-import { UseQueryProps, UseQueryResult, useQuery } from "~/query";
+import { UseQueryProps, UseQueryResult, useQuery } from "../query";
+
 import { useNetwork } from "./useNetwork";
 import { useProvider } from "./useProvider";
 

--- a/packages/core/src/hooks/useStarkProfile.ts
+++ b/packages/core/src/hooks/useStarkProfile.ts
@@ -8,7 +8,8 @@ import {
   shortString,
 } from "starknet";
 
-import { UseQueryProps, UseQueryResult, useQuery } from "~/query";
+import { UseQueryProps, UseQueryResult, useQuery } from "../query";
+
 import { StarknetTypedContract, useContract } from "./useContract";
 import { useNetwork } from "./useNetwork";
 import { useProvider } from "./useProvider";
@@ -42,6 +43,7 @@ type GetStarkprofileResponse = {
   discord?: string;
   proofOfPersonhood: boolean;
 };
+
 export type UseStarkProfileResult = UseQueryResult<
   GetStarkprofileResponse,
   Error

--- a/packages/core/src/hooks/useTransactionReceipt.ts
+++ b/packages/core/src/hooks/useTransactionReceipt.ts
@@ -2,8 +2,8 @@ import { Chain } from "@starknet-react/chains";
 import { useMemo } from "react";
 import { GetTransactionReceiptResponse, ProviderInterface } from "starknet";
 
-import { useStarknet } from "~/context/starknet";
-import { UseQueryProps, UseQueryResult, useQuery } from "~/query";
+import { useStarknet } from "../context/starknet";
+import { UseQueryProps, UseQueryResult, useQuery } from "../query";
 
 import { useInvalidateOnBlock } from "./useInvalidateOnBlock";
 

--- a/packages/core/src/hooks/useWalletRequest.ts
+++ b/packages/core/src/hooks/useWalletRequest.ts
@@ -1,8 +1,9 @@
 import { useCallback } from "react";
 import { RpcMessage, RpcTypeToMessageMap } from "starknet-types";
-import { Connector } from "~/connectors/base";
-import { useStarknet } from "~/context/starknet";
-import { UseMutationProps, UseMutationResult, useMutation } from "~/query";
+
+import { Connector } from "../connectors/base";
+import { useStarknet } from "../context/starknet";
+import { UseMutationProps, UseMutationResult, useMutation } from "../query";
 
 /** Message types for connector request call. */
 export type RequestMessageTypes = RpcMessage["type"];

--- a/packages/core/src/providers/jsonrpc.ts
+++ b/packages/core/src/providers/jsonrpc.ts
@@ -1,7 +1,7 @@
 import { Chain } from "@starknet-react/chains";
 import { RpcProvider, RpcProviderOptions } from "starknet";
 
-import { starknetChainId } from "~/context";
+import { starknetChainId } from "../context";
 import { ChainProviderFactory } from "./factory";
 
 /** Arguments for `jsonRpcProvider`. */

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "extends": "@starknet-react/typescript-config/react-library.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "baseUrl": ".",
-    "paths": {
-      "~/*": ["src/*"]
-    }
+    "outDir": "dist"
   },
   "include": ["src", "test"],
   "exclude": ["src/**/*.test.tsx", "src/**/*.test.ts"]


### PR DESCRIPTION
## Context

At the moment, any change to a package (core, chains, etc) requires compiling
the project before it can be used in the documentation.

This PR changes the default configuration used by pnpm/npm to provide Typescript
files and exports the compiled javascript files only on publish.
