### PR TITLE
core: use `Address` type for addresses

### DIFF
--- a/packages/core/src/hooks/useAccount.ts
+++ b/packages/core/src/hooks/useAccount.ts
@@ -1,3 +1,4 @@
+import { type Address } from "@starknet-react/chains";
 import { useCallback, useEffect, useState } from "react";
 import { AccountInterface } from "starknet";
 
@@ -30,7 +31,7 @@ export type UseAccountResult = {
   /** The connected account object. */
   account?: AccountInterface;
   /** The address of the connected account. */
-  address?: string;
+  address?: Address;
   /** The connected connector. */
   connector?: Connector;
   /** Connector's chain id */
@@ -92,6 +93,7 @@ export function useAccount({
       });
     }
 
+    const address = connectedAccount.address as Address;
     for (const connector of connectors) {
       if (!connector.available()) continue;
 
@@ -103,14 +105,14 @@ export function useAccount({
 
       if (connAccount && connAccount?.address === connectedAccount.address) {
         if (state.isDisconnected && onConnect !== undefined) {
-          onConnect({ address: connectedAccount.address, connector });
+          onConnect({ address, connector });
         }
 
         return setState({
           connector,
           chainId: await connector.chainId(),
           account: connectedAccount,
-          address: connectedAccount.address,
+          address,
           status: "connected",
           isConnected: true,
           isConnecting: false,
@@ -126,7 +128,7 @@ export function useAccount({
       connector: undefined,
       chainId: undefined,
       account: connectedAccount,
-      address: connectedAccount.address,
+      address,
       status: "connected",
       isConnected: true,
       isConnecting: false,

--- a/packages/core/src/hooks/useBalance.ts
+++ b/packages/core/src/hooks/useBalance.ts
@@ -1,4 +1,4 @@
-import { Chain } from "@starknet-react/chains";
+import { Address, Chain } from "@starknet-react/chains";
 import { useMemo } from "react";
 import { BlockNumber, BlockTag, CallOptions, num, shortString } from "starknet";
 
@@ -22,9 +22,9 @@ export type UseBalanceProps = UseQueryProps<
   ReturnType<typeof queryKey>
 > & {
   /** The contract's address. Defaults to the native currency. */
-  token?: string;
+  token?: Address;
   /** The address to fetch balance for. */
-  address?: string;
+  address?: Address;
   /** Whether to watch for changes. */
   watch?: boolean;
   /** Block identifier used when performing call. */

--- a/packages/core/src/hooks/useCall.ts
+++ b/packages/core/src/hooks/useCall.ts
@@ -1,4 +1,4 @@
-import { Chain } from "@starknet-react/chains";
+import { Address, Chain } from "@starknet-react/chains";
 import { useMemo } from "react";
 import {
   Abi,
@@ -37,7 +37,7 @@ export type UseCallProps = CallArgs &
     /** The target contract's ABI. */
     abi?: Abi;
     /** The target contract's address. */
-    address?: string;
+    address?: Address;
     /** Refresh data at every block. */
     watch?: boolean;
   };

--- a/packages/core/src/hooks/useContract.ts
+++ b/packages/core/src/hooks/useContract.ts
@@ -1,3 +1,4 @@
+import { Address } from "@starknet-react/chains";
 import { Abi } from "abi-wan-kanabi";
 import {
   ContractFunctions,
@@ -70,7 +71,7 @@ export interface UseContractArgs<TAbi extends Abi> {
    */
   abi?: TAbi;
   /** The contract address. */
-  address?: string;
+  address?: Address;
   /** The provider, by default it will be the current one. */
   provider?: ProviderInterface | null;
 }

--- a/packages/core/src/hooks/useReadContract.ts
+++ b/packages/core/src/hooks/useReadContract.ts
@@ -1,3 +1,4 @@
+import { Address } from "@starknet-react/chains";
 import {
   Abi,
   ExtractAbiFunction,
@@ -51,7 +52,7 @@ export type UseReadContractProps<
    */
   abi?: TAbi;
   /** The target contract's address. */
-  address?: string;
+  address?: Address;
   /** Refresh data at every block. */
   watch?: boolean;
   /** The contract's function name. */

--- a/packages/core/src/hooks/useStarkAddress.ts
+++ b/packages/core/src/hooks/useStarkAddress.ts
@@ -1,3 +1,4 @@
+import { Address } from "@starknet-react/chains";
 import { useMemo } from "react";
 import { CallData, Provider, ProviderInterface, starknetId } from "starknet";
 
@@ -15,7 +16,7 @@ export type UseStarkAddressProps = UseQueryProps<
   /** Stark name. */
   name?: string;
   /** Naming contract to use . */
-  contract?: string;
+  contract?: Address;
 };
 
 export type UseStarkAddressResult = UseQueryResult<string, Error>;

--- a/packages/core/src/hooks/useStarkName.ts
+++ b/packages/core/src/hooks/useStarkName.ts
@@ -1,3 +1,4 @@
+import { Address } from "@starknet-react/chains";
 import { useMemo } from "react";
 import { Provider, ProviderInterface } from "starknet";
 
@@ -14,9 +15,9 @@ export type StarkNameArgs = UseQueryProps<
   ReturnType<typeof queryKey>
 > & {
   /** Account address. */
-  address?: string;
+  address?: Address;
   /** Naming contract to use . */
-  contract?: string;
+  contract?: Address;
 };
 
 /** Value returned by `useStarkName` hook. */

--- a/packages/core/src/hooks/useStarkProfile.ts
+++ b/packages/core/src/hooks/useStarkProfile.ts
@@ -1,3 +1,4 @@
+import { Address } from "@starknet-react/chains";
 import { useMemo } from "react";
 import {
   CairoCustomEnum,
@@ -22,7 +23,7 @@ export type StarkProfileArgs = UseQueryProps<
   ReturnType<typeof queryKey>
 > & {
   /** Account address. */
-  address?: string;
+  address?: Address;
   /** Get Starknet ID default pfp url if no profile picture is set */
   useDefaultPfp?: boolean;
   /** Naming contract to use. */
@@ -394,12 +395,12 @@ const fetchImageUrl = async (url: string): Promise<string> => {
 
 type StarknetIdContractTypes = {
   [network: string]: {
-    naming: string;
-    identity: string;
-    verifier: string;
-    verifier_pop: string;
-    verifier_pfp: string;
-    multicall: string;
+    naming: Address;
+    identity: Address;
+    verifier: Address;
+    verifier_pop: Address;
+    verifier_pfp: Address;
+    multicall: Address;
   };
 };
 
@@ -429,7 +430,7 @@ const StarknetIdcontracts: StarknetIdContractTypes = {
     multicall:
       "0x034ffb8f4452df7a613a0210824d6414dbadcddce6c6e19bf4ddc9e22ce5f970",
   },
-};
+} as const;
 
 const multicallABI = [
   {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,4 +4,6 @@ export * from "./errors";
 export * from "./explorers";
 export * from "./providers";
 export * from "./hooks";
+
 export { type Abi } from "abi-wan-kanabi";
+export { type Address } from "@starknet-react/chains";


### PR DESCRIPTION
## Context

Require users to provide a Starknet address when needed. This ensures that
developers validate the address before using it.

