### PR TITLE
core: add useNonceForAddress hook

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,8 +1,5 @@
 {
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
-  "organizeImports": {
-    "enabled": false
-  },
   "linter": {
     "enabled": true,
     "rules": {

--- a/docs/components/demo/index.ts
+++ b/docs/components/demo/index.ts
@@ -2,6 +2,7 @@ import { AddChain } from "./add-chain";
 import { ConnectWallet } from "./connect-wallet";
 import { DeclareContract } from "./declare-contract";
 import { EstimateFees } from "./estimate-fees";
+import { NonceForAddress } from "./nonce-for-address";
 import { ReadContract } from "./read-contract";
 import { SendTransaction } from "./send-transaction";
 import { SignTypedData } from "./sign-typed-data";
@@ -22,4 +23,5 @@ export default {
   AddChain,
   SignTypedData,
   DeclareContract,
+  NonceForAddress,
 };

--- a/docs/components/demo/nonce-for-address.tsx
+++ b/docs/components/demo/nonce-for-address.tsx
@@ -1,0 +1,36 @@
+import { Address, useAccount, useNonceForAddress } from "@starknet-react/core";
+import { DemoContainer } from "../starknet";
+
+export function NonceForAddress() {
+  return (
+    <DemoContainer hasWallet>
+      <NonceForAddressInner />
+    </DemoContainer>
+  );
+}
+
+function NonceForAddressInner() {
+  const { account } = useAccount();
+
+  const { data, isLoading, isError, error } = useNonceForAddress({
+    address: account?.address as Address,
+  });
+
+  return (
+    <div className="flex flex-col">
+      <h1 className="font-bold text-lg">Nonce for Address</h1>
+      <div className="flex flex-col mt-2">
+        {account?.address ? (
+          <>
+            <div>nonce: {data} </div>
+            <div>isLoading: {isLoading ? "true" : "false"} </div>
+            <div>isError: {isError ? "true" : "false"} </div>
+            <div>error: {error ? error.message : "null"} </div>
+          </>
+        ) : (
+          "Connect your wallet to start."
+        )}
+      </div>
+    </div>
+  );
+}

--- a/docs/pages/demo/index.mdx
+++ b/docs/pages/demo/index.mdx
@@ -11,3 +11,4 @@
 - [Add Chain](/demo/add-chain)
 - [Sign Typed Data](/demo/sign-typed-data)
 - [Declare Contract (TODO)](/demo/declare-contract)
+- [Nonce for Address](/demo/nonce-for-address)

--- a/docs/pages/demo/nonce-for-address.mdx
+++ b/docs/pages/demo/nonce-for-address.mdx
@@ -1,0 +1,5 @@
+import Demo from "../../components/demo";
+
+# Nonce for Address
+
+<Demo.NonceForAddress />

--- a/docs/pages/docs/hooks/use-nonce-for-address.mdx
+++ b/docs/pages/docs/hooks/use-nonce-for-address.mdx
@@ -1,0 +1,126 @@
+# useNonceForAddress
+
+Returns the nonce associated with the given address in the given block
+
+By default this hook fetches the latest block, but you can change it with the `blockIdentifier` argument.
+
+## Usage
+
+```ts twoslash
+import { useNonceForAddress, useAccount } from "@starknet-react/core";
+import { type Address } from "@starknet-react/chains";
+
+const { account } = useAccount();
+
+const { data, isLoading, isError, error } = useNonceForAddress({
+  address: account?.address as Address,
+});
+```
+
+## Data
+
+- Type: `Nonce`
+
+The Nonce type from `starknet`.
+
+## Arguments
+
+### address
+
+- Type: `Address`
+
+Contract address.
+
+### blockIdentifier
+
+- Type: `BlockNumber | undefined`
+
+Perform the query against the provided block, e.g. `BlockTag.latest`.
+
+### enabled
+
+- Type: `boolean | undefined`
+
+If `false`, don't perform the query.
+
+### refetchInterval
+
+- Type: `number | false | ((query: Query) => number | false | undefined)`
+
+If set to a number, the query is refetched at the provided interval (in milliseconds).
+
+If set to a function, the callback will be used to determine the refetch interval.
+
+## Returns
+
+### data
+
+- Type: `Data | undefined`
+
+The resolved data.
+
+### error
+
+- Type: `Error | null`
+
+Any error thrown by the query.
+
+### reset
+
+- Type: `() => void`
+
+Reset the query status.
+
+### status
+
+- Type: `"error" | "pending" | "success"`
+
+The mutation status.
+
+- `pending`: the query is being executed.
+- `success`: the query executed without an error.
+- `error`: the query threw an error.
+
+### isError
+
+- Type: `boolean`
+
+Derived from `status`.
+
+### isPending
+
+- Type: `boolean`
+
+Derived from `status`.
+
+### isSuccess
+
+- Type: `boolean`
+
+Derived from `status`.
+
+### fetchStatus
+
+- Type: `"fetching" | "paused" | "idle"`
+
+- `fetching`: the query is fetching.
+- `paused`: the query is paused.
+- `idle`: the query is not fetching.
+
+### isFetching
+
+- Type: `boolean`
+
+Derived from `fetchStatus`.
+
+### isPaused
+
+- Type: `boolean`
+
+Derived from `fetchStatus`.
+
+### isIdle
+
+- Type: `boolean`
+
+Derived from `fetchStatus`.

--- a/docs/sidebar.ts
+++ b/docs/sidebar.ts
@@ -96,6 +96,10 @@ export const sidebar = {
           link: "/docs/hooks/use-network",
         },
         {
+          text: "useNonceForAddress",
+          link: "/docs/hooks/use-nonce-for-address",
+        },
+        {
           text: "useProvider",
           link: "/docs/hooks/use-provider",
         },

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -14,6 +14,7 @@ export * from "./use-estimate-fees";
 export * from "./use-explorer";
 export * from "./use-invalidate-on-block";
 export * from "./use-network";
+export * from "./use-nonce-for-address";
 export * from "./use-provider";
 export * from "./use-read-contract";
 export * from "./use-send-transaction";

--- a/packages/core/src/hooks/use-nonce-for-address.test.ts
+++ b/packages/core/src/hooks/use-nonce-for-address.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { renderHook, waitFor } from "../../test/react";
+
+import { useNonceForAddress } from "./use-nonce-for-address";
+
+describe("useNonceForAddress", () => {
+  it("returns nonce for the given address", async () => {
+    const { result } = renderHook(() =>
+      useNonceForAddress({
+        address:
+          "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.status).toEqual("success");
+    });
+
+    const { data, ...rest } = result.current;
+    expect(data).toEqual("0x0");
+    expect(rest).toMatchInlineSnapshot(`
+      {
+        "error": null,
+        "fetchStatus": "idle",
+        "isError": false,
+        "isFetching": false,
+        "isLoading": false,
+        "isPending": false,
+        "isSuccess": true,
+        "refetch": [Function],
+        "status": "success",
+      }
+    `);
+  });
+});

--- a/packages/core/src/hooks/use-nonce-for-address.ts
+++ b/packages/core/src/hooks/use-nonce-for-address.ts
@@ -1,0 +1,61 @@
+import { Address } from "@starknet-react/chains";
+
+import { BlockNumber, BlockTag, Nonce, ProviderInterface } from "starknet";
+
+import { useStarknet } from "../context/starknet";
+import { UseQueryProps, UseQueryResult, useQuery } from "../query";
+
+/** Arguments for `useNonceForAddress`. */
+export type UseNonceForAddressProps = UseQueryProps<
+  Nonce,
+  Error,
+  Nonce,
+  ReturnType<typeof queryKey>
+> & {
+  /** Address to fetch nonce for. */
+  address: Address;
+  /** Identifier for the block to fetch. */
+  blockIdentifier?: BlockNumber;
+};
+
+/** Value returned from `useNonceForAddress`. */
+export type UseNonceForAddressResult = UseQueryResult<Nonce, Error>;
+
+/**
+ * Hook for fetching the nonce for the given address.
+ */
+export function useNonceForAddress({
+  address,
+  blockIdentifier = BlockTag.latest,
+  ...props
+}: UseNonceForAddressProps): UseNonceForAddressResult {
+  const { provider } = useStarknet();
+
+  return useQuery({
+    queryKey: queryKey({ address, blockIdentifier }),
+    queryFn: queryFn({ address, provider, blockIdentifier }),
+    ...props,
+  });
+}
+
+function queryKey({
+  address,
+  blockIdentifier,
+}: { address: Address; blockIdentifier: BlockNumber }) {
+  return [{ entity: "nonce", blockIdentifier, address }] as const;
+}
+
+function queryFn({
+  provider,
+  blockIdentifier,
+  address,
+}: {
+  provider: ProviderInterface;
+  address: Address;
+  blockIdentifier: BlockNumber;
+}) {
+  return async () => {
+    const nonce = await provider.getNonceForAddress(address, blockIdentifier);
+    return nonce;
+  };
+}


### PR DESCRIPTION
- Add a new `useNonceForAddress` hook which fetches the nonce associated with the given address in the given block
- Resolves #470  