### PR TITLE
core: fix useAccount, replace starknet-types & bump starknet.js

### DIFF
--- a/docs/components/demo/account.tsx
+++ b/docs/components/demo/account.tsx
@@ -1,0 +1,32 @@
+import { useAccount } from "@starknet-react/core";
+import { DemoContainer } from "../starknet";
+
+export function Account() {
+  return (
+    <DemoContainer hasWallet>
+      <AccountInner />
+    </DemoContainer>
+  );
+}
+
+function AccountInner() {
+  const { address, connector } = useAccount();
+
+  return (
+    <div>
+      {address ? (
+        <>
+          <p>
+            <span className="font-bold"> Connected Account: </span> {address}
+          </p>
+          <p>
+            <span className="font-bold"> Connected Connector: </span>{" "}
+            {connector?.id}
+          </p>
+        </>
+      ) : (
+        <p>Connect Wallet first</p>
+      )}
+    </div>
+  );
+}

--- a/docs/components/demo/index.ts
+++ b/docs/components/demo/index.ts
@@ -11,8 +11,10 @@ import { StarkName } from "./stark-name";
 import { StarkProfile } from "./stark-profile";
 import { StarknetKit } from "./starknetkit";
 import { SwitchChain } from "./switch-chain";
+import { Account } from "./account";
 
 export default {
+  Account,
   ConnectWallet,
   ReadContract,
   SendTransaction,

--- a/docs/components/demo/read-contract.tsx
+++ b/docs/components/demo/read-contract.tsx
@@ -35,7 +35,7 @@ export function ReadContractInner() {
   // Cast bigint into string to avoid "TypeError: Do not know how to serialize a BigInt"
   // See https://github.com/GoogleChromeLabs/jsbi/issues/30#issuecomment-521460510
   const callResult = JSON.stringify(data, (_key, value) =>
-    typeof value === "bigint" ? value.toString() : value
+    typeof value === "bigint" ? value.toString() : value,
   );
 
   return (

--- a/docs/components/demo/read-contract.tsx
+++ b/docs/components/demo/read-contract.tsx
@@ -29,13 +29,13 @@ export function ReadContractInner() {
     args: [],
     watch: true,
     blockIdentifier:
-      blockIdentifier === "latest" ? BlockTag.latest : BlockTag.pending,
+      blockIdentifier === "latest" ? BlockTag.LATEST : BlockTag.PENDING,
   });
 
   // Cast bigint into string to avoid "TypeError: Do not know how to serialize a BigInt"
   // See https://github.com/GoogleChromeLabs/jsbi/issues/30#issuecomment-521460510
   const callResult = JSON.stringify(data, (_key, value) =>
-    typeof value === "bigint" ? value.toString() : value,
+    typeof value === "bigint" ? value.toString() : value
   );
 
   return (

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
     "@starknet-react/chains": "workspace:*",
     "@starknet-react/core": "workspace:*",
     "react": "^18.2.0",
-    "starknet": "6.9.0",
+    "starknet": "^6.12.1",
     "starknetkit": "^2.2.16",
     "vocs": "1.0.0-alpha.52"
   },

--- a/docs/pages/demo/account.mdx
+++ b/docs/pages/demo/account.mdx
@@ -1,0 +1,5 @@
+import Demo from "../../components/demo";
+
+# useAccount Demo
+
+<Demo.Account />

--- a/docs/pages/demo/index.mdx
+++ b/docs/pages/demo/index.mdx
@@ -13,3 +13,4 @@
 - [Declare Contract (TODO)](/demo/declare-contract)
 - [Nonce for Address](/demo/nonce-for-address)
 - [StarknetKit Integration](/demo/starknetkit)
+- [Account](/demo/account)

--- a/docs/pages/docs/hooks/use-balance.mdx
+++ b/docs/pages/docs/hooks/use-balance.mdx
@@ -11,32 +11,32 @@ import { useBalance } from "@starknet-react/core";
 
 const { data, error } = useBalance({
   address: "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-})
+});
 ```
 
 ## Data
 
 ### value
 
-* Type: `bigint`
+- Type: `bigint`
 
 The raw token balance.
 
 ### decimals
 
-* Type: `number`
+- Type: `number`
 
 The token decimals.
 
 ### symbol
 
-* Type: `string`
+- Type: `string`
 
 The token symbol.
 
 ### formatted
 
-* Type: `string`
+- Type: `string`
 
 The formatted token balance.
 
@@ -44,37 +44,37 @@ The formatted token balance.
 
 ### token
 
-* Type: `0x${string} | undefined`
+- Type: `0x${string} | undefined`
 
 The token address. Defaults to the chain's native currency.
 
 ### address
 
-* Type: `0x${string} | undefined`
+- Type: `0x${string} | undefined`
 
 The address to fetch the balance for.
 
 ### watch
 
-* Type: `boolean | undefined`
+- Type: `boolean | undefined`
 
 If `true`, refresh the query at every new block.
 
 ### blockIdentifier
 
-* Type: `BlockNumber | undefined`
+- Type: `BlockNumber | undefined`
 
-Perform the query against the provided block, e.g. `BlockTag.latest`.
+Perform the query against the provided block, e.g. `BlockTag.LATEST`.
 
 ### enabled
 
-* Type: `boolean | undefined`
+- Type: `boolean | undefined`
 
 If `false`, don't perform the query.
 
 ### refetchInterval
 
-* Type: `number | false | ((query: Query) => number | false | undefined)`
+- Type: `number | false | ((query: Query) => number | false | undefined)`
 
 If set to a number, the query is refetched at the provided interval (in milliseconds).
 
@@ -84,72 +84,72 @@ If set to a function, the callback will be used to determine the refetch interva
 
 ### data
 
-* Type: `Data | undefined`
+- Type: `Data | undefined`
 
 The resolved data.
 
 ### error
 
-* Type: `Error | null`
+- Type: `Error | null`
 
 Any error thrown by the query.
 
 ### reset
 
-* Type: `() => void`
+- Type: `() => void`
 
 Reset the query status.
 
 ### status
 
-* Type: `"error" | "pending" | "success"`
+- Type: `"error" | "pending" | "success"`
 
 The mutation status.
 
-* `pending`: the query is being executed.
-* `success`: the query executed without an error.
-* `error`: the query threw an error.
+- `pending`: the query is being executed.
+- `success`: the query executed without an error.
+- `error`: the query threw an error.
 
 ### isError
 
-* Type: `boolean`
+- Type: `boolean`
 
 Derived from `status`.
 
 ### isPending
 
-* Type: `boolean`
+- Type: `boolean`
 
 Derived from `status`.
 
 ### isSuccess
 
-* Type: `boolean`
+- Type: `boolean`
 
 Derived from `status`.
 
 ### fetchStatus
 
-* Type: `"fetching" | "paused" | "idle"`
+- Type: `"fetching" | "paused" | "idle"`
 
-* `fetching`: the query is fetching.
-* `paused`: the query is paused.
-* `idle`: the query is not fetching.
+- `fetching`: the query is fetching.
+- `paused`: the query is paused.
+- `idle`: the query is not fetching.
 
 ### isFetching
 
-* Type: `boolean`
+- Type: `boolean`
 
 Derived from `fetchStatus`.
 
 ### isPaused
 
-* Type: `boolean`
+- Type: `boolean`
 
 Derived from `fetchStatus`.
 
 ### isIdle
 
-* Type: `boolean`
+- Type: `boolean`
 
 Derived from `fetchStatus`.

--- a/docs/pages/docs/hooks/use-block-number.mdx
+++ b/docs/pages/docs/hooks/use-block-number.mdx
@@ -9,12 +9,12 @@ By default this hook fetches the latest block, but you can change it with the `b
 ```ts twoslash
 import { useBlockNumber } from "@starknet-react/core";
 
-const { data, error } = useBlockNumber()
+const { data, error } = useBlockNumber();
 ```
 
 ## Data
 
-* Type: `number`
+- Type: `number`
 
 The block number.
 
@@ -22,19 +22,19 @@ The block number.
 
 ### blockIdentifier
 
-* Type: `BlockNumber | undefined`
+- Type: `BlockNumber | undefined`
 
-Perform the query against the provided block, e.g. `BlockTag.latest`.
+Perform the query against the provided block, e.g. `BlockTag.LATEST`.
 
 ### enabled
 
-* Type: `boolean | undefined`
+- Type: `boolean | undefined`
 
 If `false`, don't perform the query.
 
 ### refetchInterval
 
-* Type: `number | false | ((query: Query) => number | false | undefined)`
+- Type: `number | false | ((query: Query) => number | false | undefined)`
 
 If set to a number, the query is refetched at the provided interval (in milliseconds).
 
@@ -44,72 +44,72 @@ If set to a function, the callback will be used to determine the refetch interva
 
 ### data
 
-* Type: `Data | undefined`
+- Type: `Data | undefined`
 
 The resolved data.
 
 ### error
 
-* Type: `Error | null`
+- Type: `Error | null`
 
 Any error thrown by the query.
 
 ### reset
 
-* Type: `() => void`
+- Type: `() => void`
 
 Reset the query status.
 
 ### status
 
-* Type: `"error" | "pending" | "success"`
+- Type: `"error" | "pending" | "success"`
 
 The mutation status.
 
-* `pending`: the query is being executed.
-* `success`: the query executed without an error.
-* `error`: the query threw an error.
+- `pending`: the query is being executed.
+- `success`: the query executed without an error.
+- `error`: the query threw an error.
 
 ### isError
 
-* Type: `boolean`
+- Type: `boolean`
 
 Derived from `status`.
 
 ### isPending
 
-* Type: `boolean`
+- Type: `boolean`
 
 Derived from `status`.
 
 ### isSuccess
 
-* Type: `boolean`
+- Type: `boolean`
 
 Derived from `status`.
 
 ### fetchStatus
 
-* Type: `"fetching" | "paused" | "idle"`
+- Type: `"fetching" | "paused" | "idle"`
 
-* `fetching`: the query is fetching.
-* `paused`: the query is paused.
-* `idle`: the query is not fetching.
+- `fetching`: the query is fetching.
+- `paused`: the query is paused.
+- `idle`: the query is not fetching.
 
 ### isFetching
 
-* Type: `boolean`
+- Type: `boolean`
 
 Derived from `fetchStatus`.
 
 ### isPaused
 
-* Type: `boolean`
+- Type: `boolean`
 
 Derived from `fetchStatus`.
 
 ### isIdle
 
-* Type: `boolean`
+- Type: `boolean`
 
 Derived from `fetchStatus`.

--- a/docs/pages/docs/hooks/use-block.mdx
+++ b/docs/pages/docs/hooks/use-block.mdx
@@ -9,12 +9,12 @@ By default this hook fetches the latest block, but you can change it with the `b
 ```ts twoslash
 import { useBlock } from "@starknet-react/core";
 
-const { data, error } = useBlock()
+const { data, error } = useBlock();
 ```
 
 ## Data
 
-* Type: `GetBlockResponse`
+- Type: `GetBlockResponse`
 
 The block response type from `starknet`.
 
@@ -22,19 +22,19 @@ The block response type from `starknet`.
 
 ### blockIdentifier
 
-* Type: `BlockNumber | undefined`
+- Type: `BlockNumber | undefined`
 
-Perform the query against the provided block, e.g. `BlockTag.latest`.
+Perform the query against the provided block, e.g. `BlockTag.LATEST`.
 
 ### enabled
 
-* Type: `boolean | undefined`
+- Type: `boolean | undefined`
 
 If `false`, don't perform the query.
 
 ### refetchInterval
 
-* Type: `number | false | ((query: Query) => number | false | undefined)`
+- Type: `number | false | ((query: Query) => number | false | undefined)`
 
 If set to a number, the query is refetched at the provided interval (in milliseconds).
 
@@ -44,73 +44,72 @@ If set to a function, the callback will be used to determine the refetch interva
 
 ### data
 
-* Type: `Data | undefined`
+- Type: `Data | undefined`
 
 The resolved data.
 
 ### error
 
-* Type: `Error | null`
+- Type: `Error | null`
 
 Any error thrown by the query.
 
 ### reset
 
-* Type: `() => void`
+- Type: `() => void`
 
 Reset the query status.
 
 ### status
 
-* Type: `"error" | "pending" | "success"`
+- Type: `"error" | "pending" | "success"`
 
 The mutation status.
 
-* `pending`: the query is being executed.
-* `success`: the query executed without an error.
-* `error`: the query threw an error.
+- `pending`: the query is being executed.
+- `success`: the query executed without an error.
+- `error`: the query threw an error.
 
 ### isError
 
-* Type: `boolean`
+- Type: `boolean`
 
 Derived from `status`.
 
 ### isPending
 
-* Type: `boolean`
+- Type: `boolean`
 
 Derived from `status`.
 
 ### isSuccess
 
-* Type: `boolean`
+- Type: `boolean`
 
 Derived from `status`.
 
 ### fetchStatus
 
-* Type: `"fetching" | "paused" | "idle"`
+- Type: `"fetching" | "paused" | "idle"`
 
-* `fetching`: the query is fetching.
-* `paused`: the query is paused.
-* `idle`: the query is not fetching.
+- `fetching`: the query is fetching.
+- `paused`: the query is paused.
+- `idle`: the query is not fetching.
 
 ### isFetching
 
-* Type: `boolean`
+- Type: `boolean`
 
 Derived from `fetchStatus`.
 
 ### isPaused
 
-* Type: `boolean`
+- Type: `boolean`
 
 Derived from `fetchStatus`.
 
 ### isIdle
 
-* Type: `boolean`
+- Type: `boolean`
 
 Derived from `fetchStatus`.
-

--- a/docs/pages/docs/hooks/use-call.mdx
+++ b/docs/pages/docs/hooks/use-call.mdx
@@ -78,7 +78,7 @@ Parse the return value from the contract.
 
 - Type: `BlockNumber | undefined`
 
-Perform the query against the provided block, e.g. `BlockTag.latest`.
+Perform the query against the provided block, e.g. `BlockTag.LATEST`.
 
 ### watch
 

--- a/docs/pages/docs/hooks/use-nonce-for-address.mdx
+++ b/docs/pages/docs/hooks/use-nonce-for-address.mdx
@@ -35,7 +35,7 @@ Contract address.
 
 - Type: `BlockNumber | undefined`
 
-Perform the query against the provided block, e.g. `BlockTag.latest`.
+Perform the query against the provided block, e.g. `BlockTag.LATEST`.
 
 ### enabled
 

--- a/docs/pages/docs/hooks/use-read-contract.mdx
+++ b/docs/pages/docs/hooks/use-read-contract.mdx
@@ -64,7 +64,7 @@ The contract abi which needs to be a const for type safety
 
 - Type: `BlockNumber | undefined`
 
-Perform the query against the provided block, e.g. `BlockTag.latest`.
+Perform the query against the provided block, e.g. `BlockTag.LATEST`.
 
 ### watch
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,7 +41,7 @@
   "peerDependencies": {
     "get-starknet-core": "^4.0.0-next.5",
     "react": "^18.0",
-    "starknet": "^6.9.0"
+    "starknet": "^6.12.1"
   },
   "devDependencies": {
     "@starknet-react/typescript-config": "workspace:*",
@@ -53,16 +53,16 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rimraf": "^4.1.2",
-    "starknet": "^6.9.0",
+    "starknet": "^6.12.1",
     "tsup": "^8.0.2",
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^1.5.2"
   },
   "dependencies": {
+    "@starknet-io/types-js": "^0.7.7",
     "@starknet-react/chains": "workspace:^",
     "@tanstack/react-query": "^5.25.0",
     "eventemitter3": "^5.0.1",
-    "starknet-types": "^0.7.2",
     "zod": "^3.22.4"
   }
 }

--- a/packages/core/src/connectors/base.ts
+++ b/packages/core/src/connectors/base.ts
@@ -1,11 +1,11 @@
-import EventEmitter from "eventemitter3";
-import { AccountInterface, ProviderInterface, ProviderOptions } from "starknet";
 import {
   RequestFnCall,
   RpcMessage,
   RpcTypeToMessageMap,
   StarknetWindowObject,
-} from "starknet-types";
+} from "@starknet-io/types-js";
+import EventEmitter from "eventemitter3";
+import { AccountInterface, ProviderInterface, ProviderOptions } from "starknet";
 
 /** Connector icons, as base64 encoded svg. */
 export type ConnectorIcons = StarknetWindowObject["icon"];

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -1,16 +1,16 @@
 import {
-  AccountInterface,
-  ProviderInterface,
-  ProviderOptions,
-  WalletAccount,
-} from "starknet";
-import {
   Permission,
   RequestFnCall,
   RpcMessage,
   RpcTypeToMessageMap,
   StarknetWindowObject,
-} from "starknet-types";
+} from "@starknet-io/types-js";
+import {
+  AccountInterface,
+  ProviderInterface,
+  ProviderOptions,
+  WalletAccount,
+} from "starknet";
 import {
   ConnectorNotConnectedError,
   ConnectorNotFoundError,
@@ -106,7 +106,7 @@ export class InjectedConnector extends Connector {
       type: "wallet_getPermissions",
     });
 
-    return permissions?.includes(Permission.Accounts);
+    return permissions?.includes(Permission.ACCOUNTS);
   }
 
   async account(

--- a/packages/core/src/connectors/mock.ts
+++ b/packages/core/src/connectors/mock.ts
@@ -1,10 +1,3 @@
-import { devnet, mainnet } from "@starknet-react/chains";
-import {
-  AccountInterface,
-  Call,
-  ProviderInterface,
-  ProviderOptions,
-} from "starknet";
 import {
   AddDeclareTransactionParameters,
   AddInvokeTransactionParameters,
@@ -15,7 +8,14 @@ import {
   RpcTypeToMessageMap,
   SwitchStarknetChainParameters,
   TypedData,
-} from "starknet-types";
+} from "@starknet-io/types-js";
+import { devnet, mainnet } from "@starknet-react/chains";
+import {
+  AccountInterface,
+  Call,
+  ProviderInterface,
+  ProviderOptions,
+} from "starknet";
 import {
   ConnectorNotConnectedError,
   ConnectorNotFoundError,
@@ -117,7 +117,7 @@ export class MockConnector extends Connector {
     const permissions: Permission[] = await this.request({
       type: "wallet_getPermissions",
     });
-    if (!permissions?.includes(Permission.Accounts)) {
+    if (!permissions?.includes(Permission.ACCOUNTS)) {
       return false;
     }
 
@@ -166,7 +166,7 @@ export class MockConnector extends Connector {
       case "wallet_requestChainId":
         return this._chainId.toString();
       case "wallet_getPermissions":
-        if (this._connected) return [Permission.Accounts];
+        if (this._connected) return [Permission.ACCOUNTS];
         return [];
       case "wallet_requestAccounts":
         return [this._account.address];

--- a/packages/core/src/hooks/use-account.test.ts
+++ b/packages/core/src/hooks/use-account.test.ts
@@ -75,6 +75,7 @@ describe("useAccount", () => {
             "address": "0x78662e7352d062084b0010068b99288486c2d8b914f6e2a55ce945f8792c8b1",
             "cairoVersion": undefined,
             "channel": RpcChannel2 {
+              "batchClient": undefined,
               "blockIdentifier": "pending",
               "chainId": undefined,
               "headers": {

--- a/packages/core/src/hooks/use-add-chain.ts
+++ b/packages/core/src/hooks/use-add-chain.ts
@@ -1,4 +1,4 @@
-import { AddStarknetChainParameters } from "starknet-types";
+import { AddStarknetChainParameters } from "@starknet-io/types-js";
 
 import {
   RequestArgs,

--- a/packages/core/src/hooks/use-balance.ts
+++ b/packages/core/src/hooks/use-balance.ts
@@ -46,7 +46,7 @@ export function useBalance({
   address,
   watch = false,
   enabled: enabled_ = true,
-  blockIdentifier = BlockTag.latest,
+  blockIdentifier = BlockTag.LATEST,
   ...props
 }: UseBalanceProps) {
   const { chain } = useNetwork();

--- a/packages/core/src/hooks/use-block-number.ts
+++ b/packages/core/src/hooks/use-block-number.ts
@@ -25,7 +25,7 @@ export type UseBlockNumberResult = UseQueryResult<number | undefined, Error>;
  * Control if and how often data is refreshed with `refetchInterval`.
  */
 export function useBlockNumber({
-  blockIdentifier = BlockTag.latest,
+  blockIdentifier = BlockTag.LATEST,
   ...props
 }: UseBlockNumberProps = {}): UseBlockNumberResult {
   const { provider } = useStarknet();

--- a/packages/core/src/hooks/use-block.ts
+++ b/packages/core/src/hooks/use-block.ts
@@ -31,7 +31,7 @@ export type UseBlockResult = UseQueryResult<GetBlockResponse, Error>;
  * Control if and how often data is refreshed with `refetchInterval`.
  */
 export function useBlock({
-  blockIdentifier = BlockTag.latest,
+  blockIdentifier = BlockTag.LATEST,
   ...props
 }: UseBlockProps = {}): UseBlockResult {
   const { provider } = useStarknet();

--- a/packages/core/src/hooks/use-call.ts
+++ b/packages/core/src/hooks/use-call.ts
@@ -59,7 +59,7 @@ export function useCall({
   address,
   functionName,
   args,
-  blockIdentifier = BlockTag.latest,
+  blockIdentifier = BlockTag.LATEST,
   refetchInterval: refetchInterval_,
   watch = false,
   enabled: enabled_ = true,
@@ -89,7 +89,7 @@ export function useCall({
 
   const refetchInterval =
     refetchInterval_ ??
-    (blockIdentifier === BlockTag.pending && watch
+    (blockIdentifier === BlockTag.PENDING && watch
       ? DEFAULT_FETCH_INTERVAL
       : undefined);
 

--- a/packages/core/src/hooks/use-contract.test.ts
+++ b/packages/core/src/hooks/use-contract.test.ts
@@ -187,6 +187,7 @@ describe("useContract", () => {
           },
           "providerOrAccount": RpcProvider2 {
             "channel": RpcChannel2 {
+              "batchClient": undefined,
               "blockIdentifier": "pending",
               "chainId": "0x534e5f5345504f4c4941",
               "headers": {

--- a/packages/core/src/hooks/use-declare-contract.ts
+++ b/packages/core/src/hooks/use-declare-contract.ts
@@ -1,4 +1,4 @@
-import { AddDeclareTransactionParameters } from "starknet-types";
+import { AddDeclareTransactionParameters } from "@starknet-io/types-js";
 
 import {
   RequestArgs,

--- a/packages/core/src/hooks/use-nonce-for-address.ts
+++ b/packages/core/src/hooks/use-nonce-for-address.ts
@@ -26,7 +26,7 @@ export type UseNonceForAddressResult = UseQueryResult<Nonce, Error>;
  */
 export function useNonceForAddress({
   address,
-  blockIdentifier = BlockTag.latest,
+  blockIdentifier = BlockTag.LATEST,
   ...props
 }: UseNonceForAddressProps): UseNonceForAddressResult {
   const { provider } = useStarknet();

--- a/packages/core/src/hooks/use-send-transaction.ts
+++ b/packages/core/src/hooks/use-send-transaction.ts
@@ -1,5 +1,5 @@
+import { Call as RequestCall } from "@starknet-io/types-js";
 import { Call } from "starknet";
-import { Call as RequestCall } from "starknet-types";
 import {
   RequestArgs,
   RequestResult,

--- a/packages/core/src/hooks/use-sign.ts
+++ b/packages/core/src/hooks/use-sign.ts
@@ -1,4 +1,4 @@
-import { TypedData } from "starknet-types";
+import { TypedData } from "@starknet-io/types-js";
 
 import {
   RequestArgs,

--- a/packages/core/src/hooks/use-switch-chain.ts
+++ b/packages/core/src/hooks/use-switch-chain.ts
@@ -1,4 +1,4 @@
-import { SwitchStarknetChainParameters } from "starknet-types";
+import { SwitchStarknetChainParameters } from "@starknet-io/types-js";
 
 import {
   RequestArgs,

--- a/packages/core/src/hooks/use-wallet-request.ts
+++ b/packages/core/src/hooks/use-wallet-request.ts
@@ -1,5 +1,5 @@
+import { RpcMessage, RpcTypeToMessageMap } from "@starknet-io/types-js";
 import { useCallback } from "react";
-import { RpcMessage, RpcTypeToMessageMap } from "starknet-types";
 
 import { Connector } from "../connectors/base";
 import { useStarknet } from "../context/starknet";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,11 +39,11 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0
       starknet:
-        specifier: 6.9.0
-        version: 6.9.0
+        specifier: ^6.12.1
+        version: 6.12.1
       starknetkit:
         specifier: ^2.2.16
-        version: 2.2.16(starknet@6.9.0)
+        version: 2.2.16(starknet@6.12.1)
       vocs:
         specifier: 1.0.0-alpha.52
         version: 1.0.0-alpha.52(@types/react@18.2.37)(react-dom@18.2.0)(react@18.2.0)(rollup@4.18.0)(typescript@5.3.3)
@@ -66,6 +66,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@starknet-io/types-js':
+        specifier: ^0.7.7
+        version: 0.7.7
       '@starknet-react/chains':
         specifier: workspace:^
         version: link:../chains
@@ -78,9 +81,6 @@ importers:
       get-starknet-core:
         specifier: ^4.0.0-next.5
         version: 4.0.0-next.5
-      starknet-types:
-        specifier: ^0.7.2
-        version: 0.7.2
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -113,8 +113,8 @@ importers:
         specifier: ^4.1.2
         version: 4.4.1
       starknet:
-        specifier: ^6.9.0
-        version: 6.9.0
+        specifier: ^6.12.1
+        version: 6.12.1
       tsup:
         specifier: ^8.0.2
         version: 8.0.2(typescript@5.3.3)
@@ -2437,7 +2437,6 @@ packages:
 
   /@starknet-io/types-js@0.7.7:
     resolution: {integrity: sha512-WLrpK7LIaIb8Ymxu6KF/6JkGW1sso988DweWu7p5QY/3y7waBIiPvzh27D9bX5KIJNRDyOoOVoHVEKYUYWZ/RQ==}
-    dev: false
 
   /@tanstack/query-core@5.25.0:
     resolution: {integrity: sha512-vlobHP64HTuSE68lWF1mEhwSRC5Q7gaT+a/m9S+ItuN+ruSOxe1rFnR9j0ACWQ314BPhBEVKfBQ6mHL0OWfdbQ==}
@@ -4442,18 +4441,19 @@ packages:
     resolution: {integrity: sha512-Gxc29eLs1fbn6LQ4jSU4vXjlwyZhF5HsGuMAa7gqBP4Rw4yxxltyDUuF5MBclFzDTXO+ACchGQoeela4DSfzdQ==}
     dev: false
 
-  /get-starknet-core@3.2.0(starknet@6.9.0):
+  /get-starknet-core@3.2.0(starknet@6.12.1):
     resolution: {integrity: sha512-SZhxtLlKoPKLZ2H3l9WIU7CiNmkL3qLWGksALmvZdAXa/9PykYfLtvIB5B8A2UZMpf2ojTZlWLfuo1KhgmVobA==}
     peerDependencies:
       starknet: ^5.18.0
     dependencies:
-      starknet: 6.9.0
+      starknet: 6.12.1
     dev: false
 
   /get-starknet-core@4.0.0-next.5:
     resolution: {integrity: sha512-zZ3i4E5UYF1f04fgkwfaVC0uj1pvdBlzsDqXEAfb4jc1WO4zM7rIm4XAUqdMwVSr4CBend5RM7U+zv166fBNYg==}
     dependencies:
       starknet-types: 0.7.2
+    dev: false
 
   /get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
@@ -7417,9 +7417,10 @@ packages:
   /starknet-types@0.7.2:
     resolution: {integrity: sha512-r3JJ0rrK0g3FnVRGcFiLY+9YT5WZgxB4TKBfR44wYGevHtKEM6BM5B+Gn1eou1zV7xEAwz3GpmvLSQTUAzDhsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    dev: false
 
-  /starknet@6.9.0:
-    resolution: {integrity: sha512-8860J7sGUr5UO/BDl3pjCZNUs/vgUM75wVoI93iOYLbTGF0f6MvFZsMOd73tsPKjEcG8V5BTSx6I7seDhQ9osw==}
+  /starknet@6.12.1:
+    resolution: {integrity: sha512-LLjabmmkRsBOgg0UaJtkSBBEpqeM49vULWqk06xbdm2kefcTqPLeHN4uYcZ5EqMwoqibv8rGf3a2w6IwXexeSg==}
     dependencies:
       '@noble/curves': 1.4.0
       '@noble/hashes': 1.4.0
@@ -7427,17 +7428,16 @@ packages:
       '@scure/starknet': 1.0.0
       abi-wan-kanabi: 2.2.2
       fetch-cookie: 3.0.1
-      get-starknet-core: 4.0.0-next.5
       isomorphic-fetch: 3.0.0
       lossless-json: 4.0.1
       pako: 2.1.0
-      starknet-types-07: /starknet-types@0.7.2
+      starknet-types-07: /@starknet-io/types-js@0.7.7
       ts-mixer: 6.0.4
       url-join: 4.0.1
     transitivePeerDependencies:
       - encoding
 
-  /starknetkit@2.2.16(starknet@6.9.0):
+  /starknetkit@2.2.16(starknet@6.12.1):
     resolution: {integrity: sha512-xBJ+cKspMCVH39/qG71ZSaGA1pKHcmbdUClVvRbLijphN6JEDhs6nQeYaXCDWdndavQcASgav389tJMkK+TrAA==}
     peerDependencies:
       starknet: ^6.9.0
@@ -7452,9 +7452,9 @@ packages:
       detect-browser: 5.3.0
       eventemitter3: 5.0.1
       events: 3.3.0
-      get-starknet-coreV3: /get-starknet-core@3.2.0(starknet@6.9.0)
+      get-starknet-coreV3: /get-starknet-core@3.2.0(starknet@6.12.1)
       lodash-es: 4.17.21
-      starknet: 6.9.0
+      starknet: 6.12.1
       svelte-forms: 2.3.1
       trpc-browser: 1.4.2(@trpc/client@10.45.2)(@trpc/server@10.45.2)
     transitivePeerDependencies:


### PR DESCRIPTION
- fixes `useAccount` hook and resolves #466 
- bumps `starknet` package version
- replace `starknet-types` package with `@starknet-io/types-js`
- adds demo for useAccount