### PR TITLE
Upgrade skartnetkit to latest version

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -16,7 +16,7 @@
     "@starknet-react/core": "workspace:*",
     "react": "^18.2.0",
     "starknet": "^6.12.1",
-    "starknetkit": "^2.2.24",
+    "starknetkit": "^2.2.25",
     "vocs": "1.0.0-alpha.53"
   },
   "devDependencies": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,7 +16,7 @@
     "@starknet-react/core": "workspace:*",
     "react": "^18.2.0",
     "starknet": "^6.12.1",
-    "starknetkit": "^2.2.25",
+    "starknetkit": "^2.2.26",
     "vocs": "1.0.0-alpha.53"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^6.12.1
         version: 6.12.1
       starknetkit:
-        specifier: ^2.2.25
-        version: 2.2.25(starknet@6.12.1)
+        specifier: ^2.2.26
+        version: 2.2.26(starknet@6.12.1)
       vocs:
         specifier: 1.0.0-alpha.53
         version: 1.0.0-alpha.53(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)(rollup@4.18.0)(typescript@5.5.4)
@@ -7067,8 +7067,8 @@ packages:
     transitivePeerDependencies:
       - encoding
 
-  /starknetkit@2.2.25(starknet@6.12.1):
-    resolution: {integrity: sha512-6zPkfm9dLQ1dkAtjt4dhU2nKekQBPLx66+E6dpAB0dCxg+ton1CZvCsPTAw4UEKRwA5PypqjmeqbeGeXTm60jQ==}
+  /starknetkit@2.2.26(starknet@6.12.1):
+    resolution: {integrity: sha512-X5sWwhp652oUbH9Y8x0UXFzUu95OI8VzCoLX62axyVKy5vRWuQ92tR1gwI2padiWTBrdhYQD0Ku5b++UrpU2Sw==}
     peerDependencies:
       starknet: ^6.9.0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^6.12.1
         version: 6.12.1
       starknetkit:
-        specifier: ^2.2.24
-        version: 2.2.24(starknet@6.12.1)
+        specifier: ^2.2.25
+        version: 2.2.25(starknet@6.12.1)
       vocs:
         specifier: 1.0.0-alpha.53
         version: 1.0.0-alpha.53(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)(rollup@4.18.0)(typescript@5.5.4)
@@ -7067,8 +7067,8 @@ packages:
     transitivePeerDependencies:
       - encoding
 
-  /starknetkit@2.2.24(starknet@6.12.1):
-    resolution: {integrity: sha512-4L80RCdq6AUnwUVeMA7x2XdOdZsmRFL2rgnmRPM6Thn5wFKhO+5M7O4vUwfUPJmAvGqY1ix59Lb94xub0Oc7bQ==}
+  /starknetkit@2.2.25(starknet@6.12.1):
+    resolution: {integrity: sha512-6zPkfm9dLQ1dkAtjt4dhU2nKekQBPLx66+E6dpAB0dCxg+ton1CZvCsPTAw4UEKRwA5PypqjmeqbeGeXTm60jQ==}
     peerDependencies:
       starknet: ^6.9.0
     dependencies:


### PR DESCRIPTION
# Issue
Solves #483 

# Solution
- Starknetkit was updated to its latests version `2.2.25` using `pnpm add starknetkit@next`.
- The app commands were tested to make this wasn't a breaking change (`build`, `preview`, `dev`, ...)
- The [release docs](https://github.com/argentlabs/starknetkit/releases) as well as the specific [code](https://github.com/argentlabs/starknetkit/commit/071acfb1c62ccc241f5723835db387ff2ab64488) were checked to make sure there was no breaking change or code needed to be change on the demo project.
- A complete test was performed while running the demo locally. Both argent and braavos wallet's connection was tested.