### PR TITLE
Parallel Wallet Polling in useAccount hook

### DIFF
--- a/packages/core/src/hooks/use-account.ts
+++ b/packages/core/src/hooks/use-account.ts
@@ -66,48 +66,43 @@ export function useAccount(): UseAccountResult {
       // If the account is connected, we get the address
       .filter((connector) => connector.available())
       .map(async (connector) => {
-        try {
-          // we get permissions from the wallet
-          const permissions: Permission[] = await connector.request({
-            type: "wallet_getPermissions",
-          });
+        // we get permissions from the wallet
+        const permissions: Permission[] = await connector.request({
+          type: "wallet_getPermissions",
+        });
 
-          // if the wallet doesn't have the permission to get accounts,
-          // that means the wallet is not connected and we skip it
-          if (!permissions.includes(Permission.ACCOUNTS)) return null;
+        // if the wallet doesn't have the permission to get accounts, reject
+        if (!permissions.includes(Permission.ACCOUNTS))
+          throw new Error("No permission to get accounts");
 
-          // if the wallet is connected and has permissions, so we request the accounts
-          const connAccount = await connector.request({
-            type: "wallet_requestAccounts",
-            params: { silent_mode: true },
-          });
+        // if the wallet is connected and has permissions, so we request the accounts
+        const connAccount = await connector.request({
+          type: "wallet_requestAccounts",
+          params: { silent_mode: true },
+        });
 
-          // Check if the account matches the connected account
-          if (connAccount?.[0] === connectedAccount.address) {
-            return {
-              connector,
-              chainId: await connector.chainId(),
-              account: connectedAccount,
-              address: getAddress(connectedAccount.address),
-              status: "connected" as const,
-              isConnected: true,
-              isConnecting: false,
-              isDisconnected: false,
-              isReconnecting: false,
-            };
-          }
-
-          return null; // Continue to the next connector if account doesn't match
-        } catch {
-          return null;
+        // Check if the account matches the connected account
+        if (connAccount?.[0] === connectedAccount.address) {
+          return {
+            connector,
+            chainId: await connector.chainId(),
+            account: connectedAccount,
+            address: getAddress(connectedAccount.address),
+            status: "connected" as const,
+            isConnected: true,
+            isConnecting: false,
+            isDisconnected: false,
+            isReconnecting: false,
+          };
         }
+
+        // If the account does not match, reject
+        throw new Error("Account does not match");
       });
 
     try {
       const state = await Promise.any(connectorPromises);
-      if (state) {
-        return setState(state);
-      }
+      if (state) return setState(state);
     } catch {
       // If we get here, we're not connected to any connector.
       // This can happen if it's an arcade account.


### PR DESCRIPTION
resolves #482

- removed `for` loop and added `Promise.any` for parallel polling of wallets.
- `Promise.any` will make sure to connect to the first wallet which meets the required conditions and then stop looking for wallets.
  - This would essentially reject the promises where conditions are not meeting, resolve the first promise where conditions are met and proceed ahead, ignoring other unresolved promises.