### PR TITLE
core: add disconnect event listener for wallets

### DIFF
--- a/change/@starknet-react-core-e33b670a-0093-445e-8cbc-d0a9c19083cd.json
+++ b/change/@starknet-react-core-e33b670a-0093-445e-8cbc-d0a9c19083cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "core: add disconnect event listener for wallets",
+  "packageName": "@starknet-react/core",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/context/starknet.tsx
+++ b/packages/core/src/context/starknet.tsx
@@ -192,6 +192,7 @@ function useStarknetManager({
       const needsListenerSetup = connectorRef.current?.id !== connector.id;
       if (needsListenerSetup) {
         connectorRef.current?.off("change", handleConnectorChange);
+        connectorRef.current?.off("disconnect", disconnect);
       }
 
       try {
@@ -214,6 +215,7 @@ function useStarknetManager({
 
         if (needsListenerSetup) {
           connector.on("change", handleConnectorChange);
+          connector.on("disconnect", disconnect);
         }
 
         updateChainAndProvider({ chainId });
@@ -248,6 +250,7 @@ function useStarknetManager({
 
     if (!connectorRef.current) return;
     connectorRef.current.off("change", handleConnectorChange);
+    connectorRef.current.off("disconnect", disconnect);
 
     try {
       await connectorRef.current.disconnect();


### PR DESCRIPTION
when user disconnects dApp from the wallet ui itself, it will emit `disconnect` event using which we update starknet state.
resolves #520 