### PR TITLE
Add code snippet to demo pages

### DIFF
--- a/docs/pages/demo/account.mdx
+++ b/docs/pages/demo/account.mdx
@@ -3,3 +3,10 @@ import Demo from "../../components/demo";
 # Account
 
 <Demo.Account />
+
+This demo shows how to access the currently connected account and its address.
+
+[Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/account.tsx)
+
+Hooks
+`useAccount`

--- a/docs/pages/demo/account.mdx
+++ b/docs/pages/demo/account.mdx
@@ -8,5 +8,5 @@ This demo shows how to access the currently connected account and its address.
 
 [Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/account.tsx)
 
-Hooks
-`useAccount`
+Hook(s)
+- `useAccount`

--- a/docs/pages/demo/add-chain.mdx
+++ b/docs/pages/demo/add-chain.mdx
@@ -3,3 +3,10 @@ import Demo from "../../components/demo";
 # Add Chain
 
 <Demo.AddChain />
+
+This demo shows how to add a new chain to the wallet.
+
+[Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/add-chain.tsx)
+
+Hooks
+`useAddChain`

--- a/docs/pages/demo/add-chain.mdx
+++ b/docs/pages/demo/add-chain.mdx
@@ -8,5 +8,5 @@ This demo shows how to add a new chain to the wallet.
 
 [Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/add-chain.tsx)
 
-Hooks
-`useAddChain`
+Hook(s)
+- `useAddChain`

--- a/docs/pages/demo/balance.mdx
+++ b/docs/pages/demo/balance.mdx
@@ -4,3 +4,9 @@ import Demo from "../../components/demo";
 
 <Demo.Balance />
 
+This demo shows how to fetch an ERC-20 token balance.
+
+[Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/balance.tsx)
+
+Hooks
+`useAccount` `useBalance`

--- a/docs/pages/demo/balance.mdx
+++ b/docs/pages/demo/balance.mdx
@@ -9,4 +9,5 @@ This demo shows how to fetch an ERC-20 token balance.
 [Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/balance.tsx)
 
 Hooks
-`useAccount` `useBalance`
+- `useAccount`
+- `useBalance`

--- a/docs/pages/demo/change-default-network.mdx
+++ b/docs/pages/demo/change-default-network.mdx
@@ -9,4 +9,6 @@ This demo shows how to change the default network.
 [Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/change-default-network.tsx)
 
 Hooks
-`publicProvider`, `useAccount`, `useNetwork`
+- `publicProvider`
+- `useAccount`
+- `useNetwork`

--- a/docs/pages/demo/change-default-network.mdx
+++ b/docs/pages/demo/change-default-network.mdx
@@ -3,3 +3,10 @@ import Demo from "../../components/demo";
 # Change Default Network (Todo)
 
 <Demo.ChangeDefaultNetwork />
+
+This demo shows how to change the default network.
+
+[Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/change-default-network.tsx)
+
+Hooks
+`publicProvider`, `useAccount`, `useNetwork`

--- a/docs/pages/demo/declare-contract.mdx
+++ b/docs/pages/demo/declare-contract.mdx
@@ -9,4 +9,5 @@ This demo shows how to declare a contract.
 [Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/declare-contract.tsx)
 
 Hooks
-`useAccount`, `useDeclareContract`
+- `useAccount`
+- `useDeclareContract`

--- a/docs/pages/demo/declare-contract.mdx
+++ b/docs/pages/demo/declare-contract.mdx
@@ -3,3 +3,10 @@ import Demo from "../../components/demo";
 # Declare Contract (Todo)
 
 <Demo.DeclareContract />
+
+This demo shows how to declare a contract.
+
+[Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/declare-contract.tsx)
+
+Hooks
+`useAccount`, `useDeclareContract`

--- a/docs/pages/demo/estimate-fees.mdx
+++ b/docs/pages/demo/estimate-fees.mdx
@@ -3,3 +3,10 @@ import Demo from "../../components/demo";
 # Estimate Fees
 
 <Demo.EstimateFees />
+
+This demo shows a fee estimate fees for smart contract calls.
+
+[Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/estimate-fees.tsx)
+
+Hooks
+`useAccount`, `useContract`, `useEstimateFees`, `useNetwork`

--- a/docs/pages/demo/estimate-fees.mdx
+++ b/docs/pages/demo/estimate-fees.mdx
@@ -9,4 +9,7 @@ This demo shows a fee estimate fees for smart contract calls.
 [Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/estimate-fees.tsx)
 
 Hooks
-`useAccount`, `useContract`, `useEstimateFees`, `useNetwork`
+- `useAccount`
+- `useContract`
+- `useEstimateFees`
+- `useNetwork`

--- a/docs/pages/demo/nonce-for-address.mdx
+++ b/docs/pages/demo/nonce-for-address.mdx
@@ -9,4 +9,5 @@ This demo shows how to get the nonce for an address.
 [Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/nonce-for-address.tsx)
 
 Hooks
-`useAccount`, `useNonceForAddress`
+- `useAccount`
+- `useNonceForAddress`

--- a/docs/pages/demo/nonce-for-address.mdx
+++ b/docs/pages/demo/nonce-for-address.mdx
@@ -3,3 +3,10 @@ import Demo from "../../components/demo";
 # Nonce for Address
 
 <Demo.NonceForAddress />
+
+This demo shows how to get the nonce for an address.
+
+[Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/nonce-for-address.tsx)
+
+Hooks
+`useAccount`, `useNonceForAddress`

--- a/docs/pages/demo/read-contract.mdx
+++ b/docs/pages/demo/read-contract.mdx
@@ -9,4 +9,5 @@ This demo shows how to use the `useReadContract` type-safe API to query a Starkn
 [Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/read-contract.tsx)
 
 Hooks
-`useNetwork`, `useReadContract`
+- `useNetwork`
+- `useReadContract`

--- a/docs/pages/demo/read-contract.mdx
+++ b/docs/pages/demo/read-contract.mdx
@@ -3,3 +3,10 @@ import Demo from "../../components/demo";
 # Read Contract
 
 <Demo.ReadContract />
+
+This demo shows how to use the `useReadContract` type-safe API to query a Starknet contract.
+
+[Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/read-contract.tsx)
+
+Hooks
+`useNetwork`, `useReadContract`

--- a/docs/pages/demo/send-transaction.mdx
+++ b/docs/pages/demo/send-transaction.mdx
@@ -9,4 +9,5 @@ This demo shows how to send transactions to the network.
 [Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/send-transaction.tsx)
 
 Hooks
-`useContract`, `useSendTransaction`
+- `useContract`
+- `useSendTransaction`

--- a/docs/pages/demo/send-transaction.mdx
+++ b/docs/pages/demo/send-transaction.mdx
@@ -3,3 +3,10 @@ import Demo from "../../components/demo";
 # Send Transaction
 
 <Demo.SendTransaction />
+
+This demo shows how to send transactions to the network.
+
+[Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/send-transaction.tsx)
+
+Hooks
+`useContract`, `useSendTransaction`

--- a/docs/pages/demo/sign-typed-data.mdx
+++ b/docs/pages/demo/sign-typed-data.mdx
@@ -8,5 +8,5 @@ This demo shows how to sign typed data via the wallet of the connected account.
 
 [Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/sign-typed-data.tsx)
 
-Hooks
-`useSignTypedData`
+Hook(s)
+- `useSignTypedData`

--- a/docs/pages/demo/sign-typed-data.mdx
+++ b/docs/pages/demo/sign-typed-data.mdx
@@ -3,3 +3,10 @@ import Demo from "../../components/demo";
 # Sign Typed Data
 
 <Demo.SignTypedData />
+
+This demo shows how to sign typed data via the wallet of the connected account.
+
+[Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/sign-typed-data.tsx)
+
+Hooks
+`useSignTypedData`

--- a/docs/pages/demo/stark-address.mdx
+++ b/docs/pages/demo/stark-address.mdx
@@ -8,5 +8,5 @@ This demo shows how to get the address associated to a Starknet ID.
 
 [Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/stark-address.tsx)
 
-Hooks
-`useStarkAddress`
+Hook(s)
+- `useStarkAddress`

--- a/docs/pages/demo/stark-address.mdx
+++ b/docs/pages/demo/stark-address.mdx
@@ -3,3 +3,10 @@ import Demo from "../../components/demo";
 # Stark Address
 
 <Demo.StarkAddress />
+
+This demo shows how to get the address associated to a Starknet ID.
+
+[Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/stark-address.tsx)
+
+Hooks
+`useStarkAddress`

--- a/docs/pages/demo/stark-name.mdx
+++ b/docs/pages/demo/stark-name.mdx
@@ -3,3 +3,10 @@ import Demo from "../../components/demo";
 # Stark Name
 
 <Demo.StarkName />
+
+This demo shows how to get the Starknet ID associated to an address.
+
+[Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/stark-name.tsx)
+
+Hooks
+`useStarkName`

--- a/docs/pages/demo/stark-name.mdx
+++ b/docs/pages/demo/stark-name.mdx
@@ -8,5 +8,5 @@ This demo shows how to get the Starknet ID associated to an address.
 
 [Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/stark-name.tsx)
 
-Hooks
-`useStarkName`
+Hook(s)
+- `useStarkName`

--- a/docs/pages/demo/stark-profile.mdx
+++ b/docs/pages/demo/stark-profile.mdx
@@ -3,3 +3,10 @@ import Demo from "../../components/demo";
 # Stark Profile
 
 <Demo.StarkProfile />
+
+This demo shows how to get the Starknet ID profile associated to an address.
+
+[Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/stark-profile.tsx)
+
+Hooks
+`useStarkProfile`

--- a/docs/pages/demo/stark-profile.mdx
+++ b/docs/pages/demo/stark-profile.mdx
@@ -8,5 +8,5 @@ This demo shows how to get the Starknet ID profile associated to an address.
 
 [Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/stark-profile.tsx)
 
-Hooks
-`useStarkProfile`
+Hook(s)
+- `useStarkProfile`

--- a/docs/pages/demo/starknetkit.mdx
+++ b/docs/pages/demo/starknetkit.mdx
@@ -9,5 +9,10 @@ This demo shows how to integrate Starknet React with StarknetKit.
 [Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/starknetkit.tsx)
 
 Hooks
-- starknet-react `publicProvider`, `useAccount`, `useConnect`, `useNetwork`,
-- starknetkitconnector `useStarknetkitConnectModal`
+- starknet-react
+  -`publicProvider`
+  - `useAccount`
+  - `useConnect`
+  - `useNetwork`,
+- starknetkitconnector
+  - `useStarknetkitConnectModal`

--- a/docs/pages/demo/starknetkit.mdx
+++ b/docs/pages/demo/starknetkit.mdx
@@ -3,3 +3,11 @@ import Demo from "../../components/demo";
 # StarknetKit Integration
 
 <Demo.StarknetKit />
+
+This demo shows how to integrate Starknet React with StarknetKit.
+
+[Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/starknetkit.tsx)
+
+Hooks
+- starknet-react `publicProvider`, `useAccount`, `useConnect`, `useNetwork`,
+- starknetkitconnector `useStarknetkitConnectModal`

--- a/docs/pages/demo/switch-chain.mdx
+++ b/docs/pages/demo/switch-chain.mdx
@@ -9,4 +9,6 @@ This demo shows how to switch between chains.
 [Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/switch-chain.tsx)
 
 Hooks
-`useAccount`, `useNetwork`, `useSwitchChain`
+- `useAccount`
+- `useNetwork`
+- `useSwitchChain`

--- a/docs/pages/demo/switch-chain.mdx
+++ b/docs/pages/demo/switch-chain.mdx
@@ -3,3 +3,10 @@ import Demo from "../../components/demo";
 # Switch Chain
 
 <Demo.SwitchChain />
+
+This demo shows how to switch between chains.
+
+[Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/switch-chain.tsx)
+
+Hooks
+`useAccount`, `useNetwork`, `useSwitchChain`

--- a/docs/pages/demo/wallet-permission.mdx
+++ b/docs/pages/demo/wallet-permission.mdx
@@ -8,5 +8,5 @@ This demo shows how to request wallet permissions.
 
 [Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/wallet-permission.tsx)
 
-Hooks
-`useWalletRequest`
+Hook(s)
+- `useWalletRequest`

--- a/docs/pages/demo/wallet-permission.mdx
+++ b/docs/pages/demo/wallet-permission.mdx
@@ -3,3 +3,10 @@ import Demo from "../../components/demo";
 # Wallet Permission
 
 <Demo.WalletPermission />
+
+This demo shows how to request wallet permissions.
+
+[Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/wallet-permission.tsx)
+
+Hooks
+`useWalletRequest`


### PR DESCRIPTION
closes #518 

The changes include the following
- Adds a description of the demo page
- Adds a link to github containing the source code snippet.