### PR TITLE
fix: kakarot connector

### DIFF
--- a/change/@starknet-react-kakarot-fa74fe3e-4f70-4564-b900-7956eec1f374.json
+++ b/change/@starknet-react-kakarot-fa74fe3e-4f70-4564-b900-7956eec1f374.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: kakarot multicall precompile address",
+  "packageName": "@starknet-react/kakarot",
+  "email": "mathieu@kakarot.org",
+  "dependentChangeType": "patch"
+}

--- a/packages/kakarot/package.json
+++ b/packages/kakarot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@starknet-react/kakarot",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "license": "MIT",
   "repository": "apibara/starknet-react",
   "homepage": "https://www.starknet-react.com/",

--- a/packages/kakarot/src/index.ts
+++ b/packages/kakarot/src/index.ts
@@ -1,2 +1,3 @@
 export { kakarotSepolia } from "./chains";
 export { kakarotConnectors } from "./connectors";
+export { KakarotConnector } from "./kakarot";

--- a/packages/kakarot/src/kakarot.ts
+++ b/packages/kakarot/src/kakarot.ts
@@ -49,7 +49,7 @@ import {
   getCorrespondingStarknetChain,
 } from "./chains";
 
-const MULTICALL_CAIRO_PRECOMPILE = "0x0000000000000000000000000000000000750003";
+const MULTICALL_CAIRO_PRECOMPILE = "0x0000000000000000000000000000000000075003";
 
 class ProviderNotFoundError extends Error {
   constructor() {

--- a/packages/kakarot/src/kakarot.ts
+++ b/packages/kakarot/src/kakarot.ts
@@ -369,19 +369,25 @@ export class KakarotConnector extends Connector {
         return requestedAccounts.map((x: string) => getAddress(x));
       }
       case "wallet_addStarknetChain":
-        return false;
+        throw new Error(
+          "wallet_addStarknetChain not implemented for Kakarot connectors",
+        );
       case "wallet_watchAsset":
-        return false;
+        throw new Error(
+          "wallet_watchAsset not implemented for Kakarot connectors",
+        );
       case "wallet_switchStarknetChain": {
         if (!params) throw new Error("Params are missing");
 
         const { chainId } = params as SwitchStarknetChainParameters;
 
-        this.switchChain(BigInt(chainId));
+        await this.switchChain(BigInt(chainId));
         return true;
       }
       case "wallet_addDeclareTransaction": {
-        return false;
+        throw new Error(
+          "wallet_addDeclareTransaction not implemented for Kakarot connectors",
+        );
       }
       case "wallet_addInvokeTransaction": {
         if (!params) throw new Error("Params are missing");
@@ -421,7 +427,9 @@ export class KakarotConnector extends Connector {
         //   method: "eth_signTypedData_v4",
         //   params: [accounts[0], domain, message, primaryType, types],
         // });
-        return false;
+        throw new Error(
+          "wallet_signTypedData not implemented for Kakarot connectors",
+        );
       }
       default:
         throw new Error("Unknown request type");


### PR DESCRIPTION
- Fixes the address of the kakarot multicall precompile
- Unsupported wallet_* methods now throw an error instead of returning false