### PR TITLE
fix: kakarot invoke returndata and multicall encoding

### DIFF
--- a/change/@starknet-react-kakarot-35774e84-0f76-4f61-996a-76eba0d19258.json
+++ b/change/@starknet-react-kakarot-35774e84-0f76-4f61-996a-76eba0d19258.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: kakarot invokeTransaction returndata type & multicall evm encoding",
+  "packageName": "@starknet-react/kakarot",
+  "email": "msaug@protonmail.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
- Fixes the encoding of multicalls (removes unwanted `0x` hex prefixes)
- Closes https://github.com/apibara/starknet-react/issues/530 by changing the return type for kakarot's wallet_InvokeTransaction route