### PR TITLE
kakarot: add kkrt logo overlay to connector icons

### DIFF
--- a/docs/components/starknet/bar.tsx
+++ b/docs/components/starknet/bar.tsx
@@ -5,7 +5,7 @@ export function WalletBar() {
   const { address } = useAccount();
 
   return (
-    <div className="w-full py-2 h-24 border-b border-primary">
+    <div className="w-full py-6 border-b border-primary">
       {address ? <ConnectedWallet address={address} /> : <ConnectWallet />}
     </div>
   );
@@ -24,9 +24,9 @@ function ConnectWallet() {
   const { connect, connectors, status } = useConnect();
 
   return (
-    <div className="flex h-full items-center justify-between">
-      <p className="font-medium">Connect Wallet </p>
-      <div className="flex flex-row justify-start space-x-2">
+    <div className="flex h-full items-start justify-between">
+      <p className="font-medium mr-2 mt-1 text-nowrap">Connect Wallet </p>
+      <div className="flex justify-center flex-wrap gap-2">
         {connectors.map((connector) => (
           <Button
             key={connector.id}
@@ -37,6 +37,15 @@ function ConnectWallet() {
             disabled={status === "pending"}
           >
             {connector.name}
+            <img
+              src={
+                typeof connector.icon === "string"
+                  ? connector.icon
+                  : connector.icon.dark
+              }
+              className="w-6 ml-2"
+              alt={connector.name}
+            />
           </Button>
         ))}
       </div>

--- a/packages/kakarot/src/kakarot.ts
+++ b/packages/kakarot/src/kakarot.ts
@@ -81,6 +81,37 @@ export interface KakarotConnectorOptions {
   name: string;
   icon: ConnectorIcons;
 }
+
+/**
+ * Creates an SVG icon combining the connector icon with the Kakarot overlay
+ * @param connectorIcon - Base64 or URL of the connector icon
+ * @returns SVG data URL
+ */
+const createCombinedIcon = (connectorIcon: string): string => {
+  const svgString = `
+    <svg width="100%" height="100%" viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <pattern id="connector-${btoa(connectorIcon)}" patternUnits="userSpaceOnUse" width="30" height="30">
+          <image href="${connectorIcon}" width="30" height="30" />
+        </pattern>
+      </defs>
+
+      <!-- Base connector icon -->
+      <rect width="30" height="30" fill="url(#connector-${btoa(connectorIcon)})" />
+
+      <!-- Kakarot overlay - positioned in bottom right -->
+      <g transform="translate(20, 20) scale(0.25)">
+        <path d="M36.5027 0V6.25976C28.1118 7.38002 21.6125 14.6015 21.6125 23.3059V23.5526H15.3915V23.3059C15.3915 14.6015 8.89218 7.38002 0.501221 6.25976V0C8.20526 0.753896 14.8279 5.25938 18.502 11.6636C22.1761 5.25938 28.7987 0.753896 36.5027 0Z" fill="#0DAB0C"/>
+        <path d="M15.3936 22.1167H15.4291C15.4024 22.5078 15.3936 22.9077 15.3936 23.3077V22.1167Z" fill="#0DAB0C"/>
+        <path d="M21.5774 22.1167H21.6129V23.3077C21.6129 22.9077 21.6041 22.5078 21.5774 22.1167Z" fill="#0DAB0C"/>
+        <path d="M36.503 29.7764H0.501465V35.9999H36.503V29.7764Z" fill="#FF7600"/>
+      </g>
+    </svg>
+  `;
+
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svgString)}`;
+};
+
 export class KakarotConnector extends Connector {
   private _options: KakarotConnectorOptions;
   public ethProvider: EIP1193Provider;
@@ -91,10 +122,16 @@ export class KakarotConnector extends Connector {
     starknetRpcProvider: ChainProviderFactory<RpcProvider>,
   ) {
     super();
+
+    const processedIcon =
+      typeof ethProviderDetail.info.icon === "string"
+        ? createCombinedIcon(ethProviderDetail.info.icon)
+        : ethProviderDetail.info.icon;
+
     this._options = {
       id: ethProviderDetail.info.rdns,
       name: ethProviderDetail.info.name,
-      icon: ethProviderDetail.info.icon,
+      icon: processedIcon,
     };
     this.ethProvider = ethProviderDetail.provider;
     this.starknetRpcProvider = starknetRpcProvider;


### PR DESCRIPTION
## 📖  description

this PR aims to add a kkrt logo overlay to injected connector icons
also, fixes #534 

## 📷  photo demos 

<img width="842" alt="image" src="https://github.com/user-attachments/assets/4c3dfa24-198c-4854-be5b-f489319eee95">

## 🐛  type of change

- [X] New feature (non-breaking change which adds functionality)
## 🏁  checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas