### PR TITLE
Implement `useEvents` hook

### DIFF
--- a/change/@starknet-react-core-6b51603b-833a-4afc-a653-2260fa46ed82.json
+++ b/change/@starknet-react-core-6b51603b-833a-4afc-a653-2260fa46ed82.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Implement useEvents hook",
+  "packageName": "@starknet-react/core",
+  "email": "craftedbyte97@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/docs/components/demo/events.tsx
+++ b/docs/components/demo/events.tsx
@@ -1,0 +1,80 @@
+import { useBlockNumber, useEvents, useNetwork } from "@starknet-react/core";
+import stringify from "safe-stable-stringify";
+import React from "react";
+import { DemoContainer } from "../starknet";
+import { Button } from "../ui/button";
+
+function EventsInner() {
+  const eventName = "Transfer";
+  const { chain } = useNetwork();
+  const address = chain.nativeCurrency.address;
+  const fromBlock = useBlockNumber().data - 10;
+  const toBlock = "latest";
+
+  const chunkSize = 3;
+  const {
+    data,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    status,
+  } = useEvents({ address, eventName, fromBlock, toBlock, chunkSize });
+
+  const response =
+    status === "pending" ? (
+      <p>Loading first events ...</p>
+    ) : status === "error" ? (
+      <>
+        <p>Error: {error.message}</p>
+        <pre>{stringify({ data, error }, null, 2)}</pre>
+      </>
+    ) : (
+      <>
+        <div>
+          <Button
+            onClick={() => fetchNextPage()}
+            disabled={!hasNextPage || isFetchingNextPage}
+          >
+            {isFetchingNextPage
+              ? "Loading more events ..."
+              : hasNextPage
+                ? "Load more events"
+                : "No more events to load"}
+          </Button>
+        </div>
+
+        {data.pages
+          .slice(0)
+          .reverse()
+          .map((page, i) => (
+            <div key={page.continuation_token}>
+              <p>Chunk: {data.pages.length - i}</p>
+              <pre>{stringify({ page }, null, 2)}</pre>
+            </div>
+          ))}
+      </>
+    );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p>Fetching events for</p>
+      <pre>
+        {stringify(
+          { address, eventName, fromBlock, toBlock, chunkSize },
+          null,
+          2,
+        )}
+      </pre>
+      {response}
+    </div>
+  );
+}
+
+export function Events() {
+  return (
+    <DemoContainer hasWallet>
+      <EventsInner />
+    </DemoContainer>
+  );
+}

--- a/docs/components/demo/events.tsx
+++ b/docs/components/demo/events.tsx
@@ -1,6 +1,5 @@
 import { useBlockNumber, useEvents, useNetwork } from "@starknet-react/core";
 import stringify from "safe-stable-stringify";
-import React from "react";
 import { DemoContainer } from "../starknet";
 import { Button } from "../ui/button";
 import { BlockTag } from "starknet";

--- a/docs/components/demo/events.tsx
+++ b/docs/components/demo/events.tsx
@@ -3,15 +3,16 @@ import stringify from "safe-stable-stringify";
 import React from "react";
 import { DemoContainer } from "../starknet";
 import { Button } from "../ui/button";
+import { BlockTag } from "starknet";
 
 function EventsInner() {
   const eventName = "Transfer";
   const { chain } = useNetwork();
   const address = chain.nativeCurrency.address;
   const fromBlock = useBlockNumber().data - 10;
-  const toBlock = "latest";
+  const toBlock = BlockTag.LATEST;
 
-  const chunkSize = 3;
+  const pageSize = 3;
   const {
     data,
     error,
@@ -19,14 +20,14 @@ function EventsInner() {
     hasNextPage,
     isFetchingNextPage,
     status,
-  } = useEvents({ address, eventName, fromBlock, toBlock, chunkSize });
+  } = useEvents({ address, eventName, fromBlock, toBlock, pageSize });
 
   const response =
     status === "pending" ? (
       <p>Loading first events ...</p>
     ) : status === "error" ? (
       <>
-        <p>Error: {error.message}</p>
+        <p>Error: {error?.message}</p>
         <pre>{stringify({ data, error }, null, 2)}</pre>
       </>
     ) : (
@@ -44,7 +45,7 @@ function EventsInner() {
           </Button>
         </div>
 
-        {data.pages
+        {data?.pages
           .slice(0)
           .reverse()
           .map((page, i) => (
@@ -61,7 +62,7 @@ function EventsInner() {
       <p>Fetching events for</p>
       <pre>
         {stringify(
-          { address, eventName, fromBlock, toBlock, chunkSize },
+          { address, eventName, fromBlock, toBlock, pageSize },
           null,
           2,
         )}

--- a/docs/components/demo/index.ts
+++ b/docs/components/demo/index.ts
@@ -15,6 +15,8 @@ import { StarkProfile } from "./stark-profile";
 import { StarknetKit } from "./starknetkit";
 import { SwitchChain } from "./switch-chain";
 import { WalletPermission } from "./wallet-permission";
+import { Events } from "./events";
+
 export default {
   Account,
   WalletPermission,
@@ -33,4 +35,5 @@ export default {
   StarknetKit,
   ChangeDefaultNetwork,
   DeployContract,
+  Events,
 };

--- a/docs/pages/demo/events.mdx
+++ b/docs/pages/demo/events.mdx
@@ -1,0 +1,12 @@
+import Demo from "../../components/demo";
+
+# Events
+
+<Demo.Events />
+
+This demo shows how to fetch events continuously.
+
+[Link to GitHub](https://github.com/apibara/starknet-react/blob/main/docs/components/demo/events.tsx)
+
+Hook(s)
+- `useEvents`

--- a/docs/pages/demo/index.mdx
+++ b/docs/pages/demo/index.mdx
@@ -24,6 +24,8 @@ You can find the source code for these demos [on GitHub](https://github.com/apib
 
 **[Change Default Network](/demo/change-default-network)**: Shows how to change the default network.
 
+**[Events](/demo/events)**: Shows how to fetch events continuously.
+
 ## New APIs
 
 **[Request wallet permissions](/demo/wallet-permission)**: Shows how to request wallet permissions.

--- a/docs/pages/docs/hooks/use-events.mdx
+++ b/docs/pages/docs/hooks/use-events.mdx
@@ -1,0 +1,149 @@
+# useEvents
+
+Fetch Starknet events continuously
+
+By default this hook tries to fetches all the events (5 events per page) starting from genesis but you can pass arguments for filtering
+
+## Usage
+
+Fetch ETH Transfer events:
+
+```ts twoslash
+import { useEvents } from "@starknet-react/core";
+
+const {
+  data,
+  error,
+  fetchNextPage,
+  hasNextPage,
+  isFetchingNextPage,
+} = useEvents(
+  {
+    address: "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+    eventName: "Transfer",
+    fromBlock: 442920,
+    toBlock: "latest",
+    pageSize: 10
+  }
+);
+```
+
+## Arguments
+
+### address
+
+- Type: `Address | undefined`
+
+Filter events emitted by a specific contract address
+
+### eventName
+
+- Type: `string | undefined`
+
+Filter events using an event name, e.g "Transfer".
+
+### fromBlock
+
+- Type: `BlockIdentifier | undefined`
+
+The `BlockIdentifer` type from `starknet` excluding `bigint`
+
+Start fetching events from this block, e.g 44920.
+
+### toBlock
+
+- Type: `BlockIdentifier | undefined`
+
+The `BlockIdentifer` type from `starknet` excluding `bigint`
+
+Stop fetching events at this block, e.g `BlockTag.LATEST`.
+
+### pageSize
+
+- Type: `number | undefined`
+
+The number of events returned from each individual query, default to 5.
+
+## Returns
+
+### data
+
+- Type: `InfiniteData<Events, string>`
+```
+InfiniteData<Events, string> = {
+    pages: Array<Events>; // Array containing all pages.
+    pageParams: Array<string>; // Array containing all page params.
+}
+```
+
+The `InfiniteData` type from `react-query` and the `Events` type from `starknet`.
+
+### hasNextPage
+
+- Type: `boolean`
+
+Will be true if there is a next page to be fetched
+
+### isFetchingNextPage
+
+- Type: `boolean`
+
+Will be true while fetching the next page with `fetchNextPage`.
+
+### fetchNextPage
+
+- Type: `(options?: FetchNextPageOptions) => Promise<UseEventsResult>`
+
+`UseEventsResult` is the same return type of the `useEvents` hook
+
+This function allows you to fetch the next page of events, make sure to check `isFetchingNextPage` and `hasNextPage` before calling it.
+
+If `options.cancelRefetch: boolean` is set to true, calling `fetchNextPage` repeatedly will fetch events every time, whether the previous invocation has resolved or not. Also, the result from previous invocations will be ignored. If set to false, calling `fetchNextPage` repeatedly won't have any effect until the first invocation has resolved. Default is true.
+
+### error
+
+- Type: `Error | null`
+
+Any error thrown by the query.
+
+### status
+
+- Type: `"error" | "pending" | "success"`
+
+The query status.
+
+- `pending`: the query is being executed.
+- `success`: the query executed without an error.
+- `error`: the query threw an error.
+
+### isError
+
+- Type: `boolean`
+
+Derived from `status`.
+
+### isPending
+
+- Type: `boolean`
+
+Derived from `status`.
+
+### isSuccess
+
+- Type: `boolean`
+
+Derived from `status`.
+
+### fetchStatus
+
+- Type: `"fetching" | "paused" | "idle"`
+
+- `fetching`: the query is fetching.
+- `paused`: the query is paused.
+- `idle`: the query is not fetching.
+
+### isFetching
+
+- Type: `boolean`
+
+Derived from `fetchStatus`.

--- a/docs/sidebar.ts
+++ b/docs/sidebar.ts
@@ -159,6 +159,10 @@ export const sidebar = {
           text: "useTransactionReceipt",
           link: "/docs/hooks/use-transaction-receipt",
         },
+        {
+          text: "useEvents",
+          link: "/docs/hooks/use-events",
+        },
       ],
     },
     {

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -27,3 +27,4 @@ export * from "./use-transaction-receipt";
 export * from "./use-wallet-request";
 export * from "./use-watch-asset";
 export * from "./use-universal-deployer-contract";
+export * from "./use-events";

--- a/packages/core/src/hooks/use-events.test.ts
+++ b/packages/core/src/hooks/use-events.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import { accounts, defaultConnector } from "../../test/devnet";
+import { act, renderHook, waitFor } from "../../test/react";
+
+import type { Abi } from "abi-wan-kanabi";
+import { useAccount } from "./use-account";
+import { useConnect } from "./use-connect";
+import { useContract } from "./use-contract";
+import { useDisconnect } from "./use-disconnect";
+import { useEvents } from "./use-events";
+import { useNetwork } from "./use-network";
+import { useSendTransaction } from "./use-send-transaction";
+
+function useSendTransactionWithConnect() {
+  const { chain } = useNetwork();
+
+  const { contract } = useContract({
+    abi,
+    address: chain.nativeCurrency.address,
+  });
+
+  const { address } = useAccount();
+
+  const calls =
+    contract && address
+      ? [contract.populate("transfer", [address, 1n])]
+      : undefined;
+
+  return {
+    sendTransaction: useSendTransaction({ calls }),
+    connect: useConnect(),
+    disconnect: useDisconnect(),
+  };
+}
+
+async function sendTransfer() {
+  const { result } = renderHook(() => useSendTransactionWithConnect());
+
+  await act(async () => {
+    result.current.connect.connect({
+      connector: defaultConnector,
+    });
+  });
+
+  await act(async () => {
+    result.current.sendTransaction.send();
+  });
+
+  await waitFor(() => {
+    expect(result.current.sendTransaction.isSuccess).toBeTruthy();
+  });
+}
+
+describe("useEvents", () => {
+  describe("when no transfer is sent", () => {
+    it("returns an empty events list", async () => {
+      const { result } = renderHook(() =>
+        useEvents({
+          address: accounts.sepolia[0].address as `0x${string}`,
+          eventName: "Transfer",
+          fromBlock: 0,
+          toBlock: 0,
+          chunkSize: 1,
+        }),
+      );
+
+      await waitFor(() => {
+        const { data, ...rest } = result.current;
+        expect(data).toEqual({ pages: [{ events: [] }], pageParams: ["0"] });
+        expect(rest).toMatchInlineSnapshot(`
+          {
+            "error": null,
+            "fetchNextPage": [Function],
+            "fetchPreviousPage": [Function],
+            "fetchStatus": "idle",
+            "hasNextPage": false,
+            "hasPreviousPage": false,
+            "isError": false,
+            "isFetching": false,
+            "isFetchingNextPage": false,
+            "isFetchingPreviousPage": false,
+            "isLoading": false,
+            "isPending": false,
+            "isSuccess": true,
+            "refetch": [Function],
+            "status": "success",
+          }
+        `);
+      });
+    });
+  });
+
+  describe.skip("when a transfer is sent", () => {
+    it("returns the Transfer events", async () => {
+      await sendTransfer();
+
+      const { result } = renderHook(() =>
+        useEvents({
+          address: accounts.sepolia[0].address as `0x${string}`,
+          eventName: "Transfer",
+          fromBlock: 0,
+          toBlock: 0,
+          chunkSize: 1,
+        }),
+      );
+
+      await waitFor(() => {
+        const { data, ...rest } = result.current;
+        expect(data).toBeDefined();
+        expect(rest).toMatchInlineSnapshot(`
+          {
+            "error": null,
+            "fetchNextPage": [Function],
+            "fetchPreviousPage": [Function],
+            "fetchStatus": "idle",
+            "hasNextPage": false,
+            "hasPreviousPage": false,
+            "isError": false,
+            "isFetching": false,
+            "isFetchingNextPage": false,
+            "isFetchingPreviousPage": false,
+            "isLoading": false,
+            "isPending": false,
+            "isSuccess": true,
+            "refetch": [Function],
+            "status": "success",
+          }
+        `);
+      });
+    });
+  });
+});
+
+const abi = [
+  {
+    type: "function",
+    name: "transfer",
+    state_mutability: "external",
+    inputs: [
+      {
+        name: "recipient",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+      {
+        name: "amount",
+        type: "core::integer::u256",
+      },
+    ],
+    outputs: [],
+  },
+] as const satisfies Abi;

--- a/packages/core/src/hooks/use-events.test.ts
+++ b/packages/core/src/hooks/use-events.test.ts
@@ -60,7 +60,7 @@ describe("useEvents", () => {
           eventName: "Transfer",
           fromBlock: 0,
           toBlock: 0,
-          chunkSize: 1,
+          pageSize: 1,
         }),
       );
 
@@ -100,7 +100,7 @@ describe("useEvents", () => {
           eventName: "Transfer",
           fromBlock: 0,
           toBlock: 0,
-          chunkSize: 1,
+          pageSize: 1,
         }),
       );
 

--- a/packages/core/src/hooks/use-events.ts
+++ b/packages/core/src/hooks/use-events.ts
@@ -1,0 +1,151 @@
+import type { Events } from "@starknet-io/types-js";
+import {
+  type BlockIdentifier as BlockIdentifier_,
+  BlockTag,
+  type RpcProvider,
+  hash,
+  num,
+} from "starknet";
+import {
+  type UseInfiniteQueryProps,
+  type UseInfiniteQueryResult,
+  useInfiniteQuery,
+} from "../query";
+import { useProvider } from "./use-provider";
+
+type EventsType = Events;
+type BlockIdentifier = Exclude<BlockIdentifier_, bigint>;
+
+/** Arguments for `useEvents`. */
+export type UseEventsProps = UseInfiniteQueryProps<
+  EventsType,
+  Error,
+  EventsType,
+  EventsType,
+  ReturnType<typeof queryKey>,
+  string
+> & {
+  /** Filter events emitted by a specific contract address */
+  address?: string;
+  // TODO: support complex/nested events
+  /** Filter events using the event name, example: Transfer */
+  eventName?: string;
+  /** Start fetching events from this block */
+  fromBlock?: BlockIdentifier;
+  /** Stop fetching events at this block */
+  toBlock?: BlockIdentifier;
+  /** The number of events returned from each individual query */
+  chunkSize: number;
+};
+
+/** Value returned from `useEvents`. */
+export type UseEventsResult = UseInfiniteQueryResult<EventsType, Error>;
+
+/**
+ * Hook to fetch events continuously
+ *
+ * The parameters could be used to filter the events by contract address, name
+ * or specify a range of blocks to get the events from
+ *
+ * The returned object contain different functions and props to fetch next pages
+ */
+export function useEvents({
+  address,
+  eventName,
+  fromBlock: fromBlock_,
+  toBlock: toBlock_,
+  chunkSize,
+}: UseEventsProps): UseEventsResult {
+  const { provider } = useProvider();
+  const rpcProvider = provider as RpcProvider;
+
+  const keyFilter = eventName
+    ? [num.toHex(hash.starknetKeccak(eventName))]
+    : [];
+  const keys = [keyFilter];
+
+  const fromBlock = fromBlock_
+    ? blockIdentifierToBlockId(fromBlock_)
+    : undefined;
+
+  const toBlock = toBlock_ ? blockIdentifierToBlockId(toBlock_) : undefined;
+
+  const fetchEvents = async ({
+    pageParam,
+  }: {
+    pageParam?: string;
+  }): Promise<EventsType> => {
+    const res = await rpcProvider.getEvents({
+      from_block: fromBlock,
+      to_block: toBlock,
+      address: address,
+      keys: keys,
+      chunk_size: chunkSize,
+      continuation_token: pageParam === "0" ? undefined : pageParam,
+    });
+    return res;
+  };
+
+  return useInfiniteQuery({
+    // TODO: useMemo ?
+    queryKey: queryKey({
+      address,
+      eventName,
+      fromBlock: fromBlock_,
+      toBlock: toBlock_,
+      chunkSize,
+    }),
+    queryFn: fetchEvents,
+    initialPageParam: "0",
+    getNextPageParam: (lastPage, pages) => lastPage.continuation_token,
+  });
+}
+
+function queryKey({
+  address,
+  eventName,
+  fromBlock,
+  toBlock,
+  chunkSize,
+}: {
+  address?: string;
+  eventName?: string;
+  fromBlock?: BlockIdentifier;
+  toBlock?: BlockIdentifier;
+  chunkSize?: number;
+}) {
+  return [
+    {
+      entity: "events",
+      address,
+      eventName,
+      fromBlock,
+      toBlock,
+      chunkSize,
+    },
+  ] as const;
+}
+
+// Function to transform BlockIdentifier into a BLOCK_ID
+function blockIdentifierToBlockId(blockIdentifier: BlockIdentifier) {
+  if (blockIdentifier === null) {
+    return BlockTag.PENDING; // null maps to 'pending' as per the BlockIdentifier doc
+  }
+
+  if (typeof blockIdentifier === "number") {
+    return { block_number: blockIdentifier };
+  }
+
+  if (typeof blockIdentifier === "string") {
+    if (blockIdentifier === "latest" || blockIdentifier === "pending") {
+      return blockIdentifier as BlockTag; // BlockTag values map directly
+    }
+
+    // If it's a regular string, assume it's a block hash
+    return { block_hash: blockIdentifier };
+  }
+
+  throw new Error(
+    `Unsupported BlockIdentifier type: ${typeof blockIdentifier}`,
+  );
+}

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -1,9 +1,13 @@
 import {
+  type InfiniteData,
   type QueryKey,
+  type UseInfiniteQueryOptions as UseInfiniteQueryOptions_,
+  type UseInfiniteQueryResult as UseInfiniteQueryResult_,
   type UseMutationOptions as UseMutationOptions_,
   type UseMutationResult as UseMutationResult_,
   type UseQueryOptions as UseQueryOptions_,
   type UseQueryResult as UseQueryResult_,
+  useInfiniteQuery as useInfiniteQuery_,
   useMutation as useMutation_,
   useQuery as useQuery_,
 } from "@tanstack/react-query";
@@ -109,5 +113,82 @@ export function useMutation<
     mutateAsync: base.mutateAsync,
     status: base.status,
     variables: base.variables,
+  };
+}
+
+export type UseInfiniteQueryProps<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+  TPageParam = unknown,
+> = Pick<
+  UseInfiniteQueryOptions_<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryData,
+    TQueryKey,
+    TPageParam
+  >,
+  "enabled" | "refetchInterval" | "retry" | "retryDelay"
+>;
+
+export type UseInfiniteQueryResult<TData, TError> = Pick<
+  UseInfiniteQueryResult_<TData, TError>,
+  | "data"
+  | "error"
+  | "status"
+  | "isSuccess"
+  | "isError"
+  | "isPending"
+  | "fetchStatus"
+  | "isFetching"
+  | "isLoading"
+  | "refetch"
+  | "fetchNextPage"
+  | "fetchPreviousPage"
+  | "hasNextPage"
+  | "hasPreviousPage"
+  | "isFetchingNextPage"
+  | "isFetchingPreviousPage"
+>;
+
+export function useInfiniteQuery<
+  TQueryFnData,
+  TError = unknown,
+  TData = InfiniteData<TQueryFnData>,
+  TQueryKey extends QueryKey = QueryKey,
+  TPageParam = unknown,
+>(
+  args: UseInfiniteQueryOptions_<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryFnData,
+    TQueryKey,
+    TPageParam
+  >,
+): UseInfiniteQueryResult<TData, TError> {
+  const base = useInfiniteQuery_({ ...args, structuralSharing: false });
+
+  return {
+    data: base.data,
+    error: base.error,
+    status: base.status,
+    isSuccess: base.isSuccess,
+    isError: base.isError,
+    isPending: base.isPending,
+    fetchStatus: base.fetchStatus,
+    isFetching: base.isFetching,
+    isLoading: base.isLoading,
+    refetch: base.refetch,
+    fetchNextPage: base.fetchNextPage,
+    fetchPreviousPage: base.fetchPreviousPage,
+    hasNextPage: base.hasNextPage,
+    hasPreviousPage: base.hasPreviousPage,
+    isFetchingNextPage: base.isFetchingNextPage,
+    isFetchingPreviousPage: base.isFetchingPreviousPage,
   };
 }

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -135,8 +135,8 @@ export type UseInfiniteQueryProps<
   "enabled" | "refetchInterval" | "retry" | "retryDelay"
 >;
 
-export type UseInfiniteQueryResult<TData, TError> = Pick<
-  UseInfiniteQueryResult_<TData, TError>,
+export type UseInfiniteQueryResult<TData, TPageParam, TError> = Pick<
+  UseInfiniteQueryResult_<InfiniteData<TData, TPageParam>, TError>,
   | "data"
   | "error"
   | "status"
@@ -170,7 +170,7 @@ export function useInfiniteQuery<
     TQueryKey,
     TPageParam
   >,
-): UseInfiniteQueryResult<TData, TError> {
+) {
   const base = useInfiniteQuery_({ ...args, structuralSharing: false });
 
   return {


### PR DESCRIPTION
In this PR, an implementation for a new hook `useEvents` that supports fetching Starknet events continuously, a demo is available to show how to use it


https://github.com/user-attachments/assets/4748c568-e816-42fe-bed4-b8f3b33bdb0f



Closes #465