### PR TITLE
fix: re exports packages

### DIFF
--- a/change/@starknet-react-core-b3c27a78-1dce-463e-aba8-3639dc04e904.json
+++ b/change/@starknet-react-core-b3c27a78-1dce-463e-aba8-3639dc04e904.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: re exports packages",
+  "packageName": "@starknet-react/core",
+  "email": "princanurag07@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/providers/index.ts
+++ b/packages/core/src/providers/index.ts
@@ -5,7 +5,9 @@ export * from "./public";
 
 export * from "./alchemy";
 export * from "./blast";
+export * from "./cartridge";
 export * from "./infura";
 export * from "./lava";
 export * from "./nethermind";
 export * from "./reddio";
+export * from "./slot";


### PR DESCRIPTION
This adds re-exports for cartridge and slot, these are not available in latest versions. 