### PR TITLE
docs: update Cartridge Controller configuration in getting-started guide

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
     "format": "biome format components --write"
   },
   "dependencies": {
-    "@cartridge/connector": "^0.5.0-alpha.2",
+    "@cartridge/connector": "^0.6.0",
     "@radix-ui/react-checkbox": "^1.1.1",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-select": "^2.1.1",

--- a/docs/pages/docs/getting-started.mdx
+++ b/docs/pages/docs/getting-started.mdx
@@ -1,4 +1,5 @@
 import { Callout } from 'vocs/components'
+import { constants } from "starknet";
 
 
 # Getting Started
@@ -165,9 +166,18 @@ import {
 } from "@starknet-react/core";
 
 import { ControllerConnector } from "@cartridge/connector";
+import { constants } from "@starknet-react/core";
 
 const cartridgeConnector = new ControllerConnector({
-  rpc: cartridgeProvider().nodeUrl,
+  chains: [
+    {
+      rpcUrl: "https://api.cartridge.gg/x/starknet/sepolia",
+    },
+    {
+      rpcUrl: "https://api.cartridge.gg/x/starknet/mainnet",
+    },
+  ],
+  defaultChainId: constants.StarknetChainId.SN_SEPOLIA,
 });
 
 export function StarknetProvider({ children }: { children: React.ReactNode }) {
@@ -175,7 +185,7 @@ export function StarknetProvider({ children }: { children: React.ReactNode }) {
     <StarknetConfig
       chains={[mainnet, sepolia]}
       provider={cartridgeProvider()}
-      connectors={[cartridgeConnector as never as Connector]}
+      connectors={[cartridgeConnector]}
       explorer={voyager}
     >
       {children}


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/e3bb6caf-9e6d-4281-8eb5-a3bd97a7bc51)

## Changes
- Update ControllerConnector configuration example to align with @cartridge/connector v0.6.0 API
- Add proper chains configuration with Sepolia and Mainnet RPC URLs
- Add defaultChainId parameter using StarknetChainId.SN_SEPOLIA
- Import required constants from starknet and @starknet-react/core packages

## Reason for changes
The current getting-started guide uses an outdated configuration that's incompatible with the latest @cartridge/connector v0.6.0. This PR updates the example code to prevent TypeScript errors and ensure proper functionality with the current version.

## Testing
- Verified the updated configuration works with @cartridge/connector v0.6.0
- Confirmed all TypeScript errors are resolved
- Tested connectivity with both Sepolia and Mainnet networks