### PR TITLE
core: useAccount address on initial render

### DIFF
--- a/change/@starknet-react-core-55fc48f8-fbc6-461f-b588-5ec9b69b3da0.json
+++ b/change/@starknet-react-core-55fc48f8-fbc6-461f-b588-5ec9b69b3da0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "core: useAccount address on initial render",
+  "packageName": "@starknet-react/core",
+  "email": "dave.vodrazka@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/hooks/use-account.ts
+++ b/packages/core/src/hooks/use-account.ts
@@ -48,9 +48,23 @@ export function useAccount(): UseAccountResult {
   const { connector, chain } = useStarknet();
   const { provider } = useProvider();
   const { address: connectedAddress } = useStarknetAccount();
-  const [state, setState] = useState<UseAccountResult>({
-    status: "disconnected",
-  });
+  const [state, setState] = useState<UseAccountResult>(
+    connectedAddress === undefined
+      ? {
+          status: "disconnected",
+        }
+      : {
+          status: "connected" as const,
+          connector,
+          chainId: chain.id,
+          account: undefined,
+          address: getAddress(connectedAddress),
+          isConnected: true,
+          isConnecting: false,
+          isDisconnected: false,
+          isReconnecting: false,
+        },
+  );
 
   const refreshState = useCallback(async () => {
     if (connector && provider && connectedAddress) {


### PR DESCRIPTION
## The problem
When user connects their wallet and then a component using `useAccount` hook is mounted, the address is `undefined` and then updated to user's address immediately.
This lead to showing of loading state for a split second, which makes the app "flicker".

## The solution
If user address is set on the Provider, the initial state of `useAccount` is `connected` with user address.