### PR TITLE
Updates Tankstack Query to Tanstack Query

### DIFF
--- a/docs/pages/docs/getting-started.mdx
+++ b/docs/pages/docs/getting-started.mdx
@@ -13,7 +13,7 @@ free to open an issue on GitHub.
 
 Starknet React is a collection of React hooks for Starknet. It combines the following packages:
 
-- [Tankstack Query](https://tanstack.com/query/latest) for data fetching.
+- [Tanstack Query](https://tanstack.com/query/latest) for data fetching.
 - [Starknet.js](https://www.starknetjs.com/) for interacting with Starknet.
 - [abi-wan-kanabi](https://github.com/keep-starknet-strange/abi-wan-kanabi) for type-safe contract calls.
 


### PR DESCRIPTION
This PR corrects a typo in the documentation where "Tankstack Query" was mistakenly written instead of "Tanstack Query." This fix ensures the correct naming of the Tanstack Query library and improves clarity in the documentation.