### PR TITLE
Rename Argent to Ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ import { sepolia } from "@starknet-react/chains";
 import {
   StarknetConfig,
   publicProvider,
-  argent,
+  ready,
   braavos,
 } from "@starknet-react/core";
 
 function App() {
   const chains = [sepolia];
   const provider = publicProvider();
-  const connectors = [braavos(), argent()];
+  const connectors = [braavos(), ready()];
 
   return (
     <StarknetConfig chains={chains} provider={provider} connectors={connectors}>

--- a/change/@starknet-react-core-d76d2b5e-d4f0-4eba-9467-ffffd0bf6634.json
+++ b/change/@starknet-react-core-d76d2b5e-d4f0-4eba-9467-ffffd0bf6634.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "core: rename Argent to Ready",
+  "packageName": "@starknet-react/core",
+  "email": "francesco@ceccon.me",
+  "dependentChangeType": "patch"
+}

--- a/change/create-starknet-c268a259-98a7-4caf-b583-8bd7118fe629.json
+++ b/change/create-starknet-c268a259-98a7-4caf-b583-8bd7118fe629.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "core: rename Argent to Ready",
+  "packageName": "create-starknet",
+  "email": "francesco@ceccon.me",
+  "dependentChangeType": "patch"
+}

--- a/docs/components/starknet/bar.tsx
+++ b/docs/components/starknet/bar.tsx
@@ -46,7 +46,6 @@ function ConnectWallet() {
             onClick={async () => {
               await connectAsync({ connector });
             }}
-            // className="bg-red-500 rounded px-2 py-1 text-white disabled:bg-gray-500"
             disabled={status === "pending"}
           >
             {connector.name}

--- a/docs/components/starknet/provider.tsx
+++ b/docs/components/starknet/provider.tsx
@@ -2,7 +2,7 @@ import { mainnet, sepolia } from "@starknet-react/chains";
 import {
   type ExplorerFactory,
   StarknetConfig,
-  argent,
+  ready,
   braavos,
   publicProvider,
   useInjectedConnectors,
@@ -22,7 +22,7 @@ export function StarknetProvider({
   const provider = publicProvider();
   const { connectors } = useInjectedConnectors({
     // Show these connectors if the user has no connector installed.
-    recommended: [argent(), braavos()],
+    recommended: [ready(), braavos()],
     // Hide recommended connectors if the user has any connector installed.
     includeRecommended: "always",
     // Randomize the order of the connectors.

--- a/docs/pages/docs/getting-started.mdx
+++ b/docs/pages/docs/getting-started.mdx
@@ -58,7 +58,7 @@ import { sepolia, mainnet } from "@starknet-react/chains";
 import {
   StarknetConfig,
   publicProvider,
-  argent,
+  ready,
   braavos,
   useInjectedConnectors,
   voyager
@@ -68,7 +68,7 @@ export function StarknetProvider({ children }: { children: React.ReactNode }) {
   const { connectors } = useInjectedConnectors({
     // Show these connectors if the user has no connector installed.
     recommended: [
-      argent(),
+      ready(),
       braavos(),
     ],
     // Hide recommended connectors if the user has any connector installed.
@@ -156,7 +156,7 @@ import { sepolia, mainnet } from "@starknet-react/chains";
 import {
   StarknetConfig,
   publicProvider,
-  argent,
+  ready,
   braavos,
   useInjectedConnectors,
   voyager,

--- a/docs/pages/docs/hooks/use-injected-connectors.mdx
+++ b/docs/pages/docs/hooks/use-injected-connectors.mdx
@@ -5,11 +5,11 @@ Hook for discovering injected wallets.
 ## Usage
 
 ```ts twoslash
-import { useInjectedConnectors, argent, braavos } from "@starknet-react/core";
+import { useInjectedConnectors, ready, braavos } from "@starknet-react/core";
 
 const { connectors } = useInjectedConnectors({
   // Show these connectors if the user has no connector installed.
-  recommended: [argent(), braavos()],
+  recommended: [ready(), braavos()],
   // Hide recommended connectors if the user has any connector installed.
   includeRecommended: "onlyIfNoConnectors",
   // Randomize the order of the connectors.

--- a/docs/pages/docs/wallets.mdx
+++ b/docs/pages/docs/wallets.mdx
@@ -37,15 +37,15 @@ import { injected } from "@starknet-react/core";
 const connector = injected({ id: "my-wallet" });
 ```
 
-### Argent X
+### Ready Wallet (formerly Argent X)
 
-The Argent X wallet is supported out of the box.
+The Ready Wallet (formerly Argent X) wallet is supported out of the box.
 
 ```tsx twoslash
-import { argent } from "@starknet-react/core";
+import { ready } from "@starknet-react/core";
 
 const connectors = [
-  argent()
+  ready()
 ];
 ```
 

--- a/packages/core/src/connectors/discovery.ts
+++ b/packages/core/src/connectors/discovery.ts
@@ -61,20 +61,22 @@ function mergeConnectors(
     order,
   }: Required<Pick<UseInjectedConnectorsProps, "includeRecommended" | "order">>,
 ): Connector[] {
-  const injectedIds = new Set(injected.map((connector) => connector.id));
-  const allConnectors = [...injected];
+  const recommendedIds = new Set(recommended.map((connector) => connector.id));
   const shouldAddRecommended =
     includeRecommended === "always" ||
     (includeRecommended === "onlyIfNoConnectors" && injected.length === 0);
+  const allConnectors = [];
   if (shouldAddRecommended) {
-    allConnectors.push(
-      ...recommended.filter((connector) => !injectedIds.has(connector.id)),
-    );
+    allConnectors.push(...recommended);
   }
+  allConnectors.push(
+    ...injected.filter((connector) => !recommendedIds.has(connector.id)),
+  );
 
   if (order === "random") {
     return shuffle(allConnectors);
   }
+
   return allConnectors.sort((a, b) => a.id.localeCompare(b.id));
 }
 

--- a/packages/core/src/connectors/helpers.ts
+++ b/packages/core/src/connectors/helpers.ts
@@ -1,14 +1,16 @@
 import { InjectedConnector } from "./injected";
 import { LegacyInjectedConnector } from "./legacy";
 
-export function argent(): InjectedConnector {
+export function ready(): InjectedConnector {
   return new InjectedConnector({
     options: {
       id: "argentX",
-      name: "Argent X",
+      name: "Ready Wallet (formerly Argent)",
     },
   });
 }
+
+export const argent = ready;
 
 export function braavos(): InjectedConnector {
   return new InjectedConnector({
@@ -29,7 +31,9 @@ export function injected({ id }: { id: string }): InjectedConnector {
 
 export function legacyInjected({
   id,
-}: { id: string }): LegacyInjectedConnector {
+}: {
+  id: string;
+}): LegacyInjectedConnector {
   return new LegacyInjectedConnector({
     options: {
       id,

--- a/packages/core/src/connectors/index.ts
+++ b/packages/core/src/connectors/index.ts
@@ -14,4 +14,4 @@ export {
   type MockConnectorAccounts,
   type MockConnectorOptions,
 } from "./mock";
-export { argent, braavos, injected, legacyInjected } from "./helpers";
+export { argent, braavos, injected, legacyInjected, ready } from "./helpers";

--- a/packages/create-starknet/src/templates/next/src/components/starknet-provider.tsx
+++ b/packages/create-starknet/src/templates/next/src/components/starknet-provider.tsx
@@ -4,9 +4,9 @@ import type { ReactNode } from "react";
 import { mainnet } from "@starknet-react/chains";
 import {
   StarknetConfig,
-  argent,
   braavos,
   publicProvider,
+  ready,
   useInjectedConnectors,
   voyager,
 } from "@starknet-react/core";
@@ -14,7 +14,7 @@ import {
 export function StarknetProvider({ children }: { children: ReactNode }) {
   const { connectors } = useInjectedConnectors({
     // Show these connectors if the user has no connector installed.
-    recommended: [argent(), braavos()],
+    recommended: [ready(), braavos()],
     // Hide recommended connectors if the user has any connector installed.
     includeRecommended: "onlyIfNoConnectors",
     // Randomize the order of the connectors.

--- a/packages/create-starknet/src/templates/vite/src/main.tsx
+++ b/packages/create-starknet/src/templates/vite/src/main.tsx
@@ -1,9 +1,9 @@
 import { mainnet } from "@starknet-react/chains";
 import {
   StarknetConfig,
-  argent,
   braavos,
   publicProvider,
+  ready,
   useInjectedConnectors,
 } from "@starknet-react/core";
 import React from "react";
@@ -16,7 +16,7 @@ export default function Root({ children }: { children: React.ReactNode }) {
   const provider = publicProvider();
   const { connectors } = useInjectedConnectors({
     // Show these connectors if the user has no connector installed.
-    recommended: [argent(), braavos()],
+    recommended: [ready(), braavos()],
     // Randomize the order of the connectors.
     order: "random",
   });


### PR DESCRIPTION
## Context

Argent rebranded to Ready. This PR updates the name.

We also update the discovery mechanism to use the wallet name hardcoded in the library to avoid content flashing once the injected wallet is discovered.
