### PR TITLE
core: fix wallet connection and wrong account on network switch

### DIFF
--- a/change/@starknet-react-core-b60b3cf8-5748-4f78-a2d2-9b2232228eac.json
+++ b/change/@starknet-react-core-b60b3cf8-5748-4f78-a2d2-9b2232228eac.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "core: fix wallet.connect and wrong acc on network switch while connect",
+  "packageName": "@starknet-react/core",
+  "email": "jadejajaipal5@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/core/src/connectors/injected.ts
+++ b/packages/core/src/connectors/injected.ts
@@ -137,14 +137,13 @@ export class InjectedConnector extends Connector {
       throw new ConnectorNotFoundError();
     }
 
-    // if chainIdHint is provided, we need to make sure the chain is correct when we connect
-    if (_args.chainIdHint) {
-      const chainId = await this.requestChainId();
-      // if the chainId is not the same as the hint, we need to switch the chain
-      if (chainId !== _args.chainIdHint) {
-        await this.switchChain(_args.chainIdHint);
-      }
-    }
+    this._wallet.on("accountsChanged", async (accounts) => {
+      await this.onAccountsChanged(accounts);
+    });
+
+    this._wallet.on("networkChanged", (chainId, accounts) => {
+      this.onNetworkChanged(chainId, accounts);
+    });
 
     const accounts = await this.request({
       type: "wallet_requestAccounts",
@@ -154,15 +153,14 @@ export class InjectedConnector extends Connector {
       throw new UserRejectedRequestError();
     }
 
-    this._wallet.on("accountsChanged", async (accounts) => {
-      await this.onAccountsChanged(accounts);
-    });
-
-    this._wallet.on("networkChanged", (chainId, accounts) => {
-      this.onNetworkChanged(chainId, accounts);
-    });
-
-    await this.onAccountsChanged(accounts);
+    // if chainIdHint is provided, we need to make sure the chain is correct when we connect
+    if (_args.chainIdHint) {
+      const chainId = await this.requestChainId();
+      // if the chainId is not the same as the hint, we need to switch the chain
+      if (chainId !== _args.chainIdHint) {
+        await this.switchChain(_args.chainIdHint);
+      }
+    }
 
     const [account] = accounts;
 


### PR DESCRIPTION
Fixes broken wallet connection from the previous release and resolves an issue where, if the dApp connects to `sepolia` while the wallet is on `mainnet`, the wallet correctly switches to `sepolia`, but the accounts request is made before the switch. As a result, a `mainnet` account was returned instead of a `sepolia` one.

This behavior was supposed to be handled by the `accountsChanged` event, but in the existing code the event handlers were registered *after* requesting accounts, so the event never fired. Now, the event handlers are registered *before* requesting accounts and switching chains which resolves this bug.
