### PR TITLE
chore: bump starknet.js to v10

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -29,7 +29,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "safe-stable-stringify": "^2.5.0",
-    "starknet": "^9.4.2",
+    "starknet": "^10.0.2",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.17",
     "tw-animate-css": "^1.4.0",

--- a/packages/create-starknet/src/templates/next/package.json
+++ b/packages/create-starknet/src/templates/next/package.json
@@ -19,7 +19,7 @@
     "next": "16.2.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "starknet": "^9.4.2"
+    "starknet": "^10.0.2"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/packages/create-starknet/src/templates/tanstack-start/package.json
+++ b/packages/create-starknet/src/templates/tanstack-start/package.json
@@ -26,7 +26,7 @@
     "@tanstack/router-plugin": "^1.132.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "starknet": "^9.4.2",
+    "starknet": "^10.0.2",
     "tailwindcss": "^4.1.18"
   },
   "devDependencies": {

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@starknet-start/chains": "workspace:^",
-    "starknet": "^9.4.2"
+    "starknet": "^10.0.2"
   },
   "devDependencies": {
     "@starknet-start/typescript-config": "workspace:^",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -46,6 +46,6 @@
     "vitest": "^4.0.15"
   },
   "peerDependencies": {
-    "starknet": "^9.4.2"
+    "starknet": "^10.0.2"
   }
 }

--- a/packages/query/src/events.ts
+++ b/packages/query/src/events.ts
@@ -70,9 +70,10 @@ function blockIdentifierToBlockId(blockIdentifier: BlockIdentifier) {
   }
 
   if (typeof blockIdentifier === "string") {
-    if (blockIdentifier === "latest" || blockIdentifier === "pending") {
-      return blockIdentifier as BlockTag;
-    }
+    if (blockIdentifier === "latest") return BlockTag.LATEST;
+    // "pending" was renamed to "pre_confirmed" in starknet RPC 0.9; accept both for compat.
+    if (blockIdentifier === "pending" || blockIdentifier === "pre_confirmed") return BlockTag.PRE_CONFIRMED;
+    if (blockIdentifier === "l1_accepted") return BlockTag.L1_ACCEPTED;
 
     return { block_hash: blockIdentifier };
   }

--- a/packages/query/src/stark-address.ts
+++ b/packages/query/src/stark-address.ts
@@ -1,6 +1,6 @@
 import type { Address } from "@starknet-start/chains";
 
-import { CallData, Provider, type ProviderInterface, starknetId } from "starknet";
+import { type ProviderInterface, StarknetIdImpl } from "starknet";
 
 export type StarkAddressQueryKeyParams = {
   name?: string;
@@ -34,26 +34,10 @@ export function starkAddressQueryFn({ name, contract, provider, network }: Stark
     if (!network) throw new Error("network is required");
 
     const namingContract = contract ?? StarknetIdNamingContract[network];
-    const p = new Provider(provider);
-    const encodedDomain = encodeDomain(name);
-    const result = await p.callContract({
-      contractAddress: namingContract as string,
-      entrypoint: "domain_to_address",
-      calldata: CallData.compile({ domain: encodedDomain, hint: [] }),
-    });
+    const result = await StarknetIdImpl.getAddressFromStarkName(provider, name, namingContract);
 
-    if (BigInt(result[0]) === BigInt(0)) throw new Error("Address not found");
+    if (BigInt(result) === BigInt(0)) throw new Error("Address not found");
 
-    return result[0] as Address;
+    return result as Address;
   };
 }
-
-const encodeDomain = (domain: string): string[] => {
-  if (!domain) return ["0"];
-
-  const encoded = [];
-  for (const subdomain of domain.replace(".stark", "").split(".")) {
-    encoded.push(starknetId.useEncoded(subdomain).toString(10));
-  }
-  return encoded;
-};

--- a/packages/query/src/stark-name.ts
+++ b/packages/query/src/stark-name.ts
@@ -1,6 +1,6 @@
 import type { Address } from "@starknet-start/chains";
 
-import { Provider, type ProviderInterface } from "starknet";
+import { type ProviderInterface, StarknetIdImpl } from "starknet";
 
 export type StarkNameQueryKeyParams = {
   address?: string;
@@ -34,7 +34,6 @@ export function starkNameQueryFn({ address, contract, provider, network }: Stark
     if (!network) throw new Error("network is required");
 
     const namingContract = contract ?? StarknetIdNamingContract[network];
-    const p = new Provider(provider);
-    return await p.getStarkName(address as Address, namingContract);
+    return await StarknetIdImpl.getStarkName(provider, address as Address, namingContract);
   };
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -58,7 +58,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "rimraf": "^4.1.2",
-    "starknet": "^9.4.2",
+    "starknet": "^10.0.2",
     "tsdown": "^0.16.8",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^4.0.15"
@@ -68,6 +68,6 @@
     "@starknet-io/get-starknet-modal": ">=5.0.0",
     "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
     "react": ">=19.0.0",
-    "starknet": ">=9.0.0"
+    "starknet": ">=10.0.0"
   }
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -51,13 +51,13 @@
     "@starknet-start/typescript-config": "workspace:^",
     "@vue/test-utils": "^2.4.6",
     "rimraf": "^4.1.2",
-    "starknet": "^9.4.2",
+    "starknet": "^10.0.2",
     "tsup": "^8.0.2",
     "vitest": "^4.0.15",
     "vue": "^3.4.0"
   },
   "peerDependencies": {
-    "starknet": "^9.4.2",
+    "starknet": "^10.0.2",
     "vue": "^3.4.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
     dependencies:
       '@cartridge/connector':
         specifier: ^0.11.2
-        version: 0.11.2(@starknet-react/core@4.0.1-beta.4(bufferutil@4.0.9)(get-starknet-core@4.0.0)(react@19.2.4)(starknet@9.4.2(typescript@5.9.3)(zod@3.25.76))(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+        version: 0.11.2(@starknet-react/core@4.0.1-beta.4(bufferutil@4.0.9)(get-starknet-core@4.0.0)(react@19.2.4)(starknet@10.0.2(typescript@5.9.3)(zod@3.25.76))(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@cartridge/controller':
         specifier: ^0.11.2
         version: 0.11.2(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -87,8 +87,8 @@ importers:
         specifier: ^2.5.0
         version: 2.5.0
       starknet:
-        specifier: ^9.4.2
-        version: 9.4.2(typescript@5.9.3)(zod@3.25.76)
+        specifier: ^10.0.2
+        version: 10.0.2(typescript@5.9.3)(zod@3.25.76)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -195,8 +195,8 @@ importers:
         specifier: workspace:^
         version: link:../chains
       starknet:
-        specifier: ^9.4.2
-        version: 9.4.2(typescript@5.9.3)
+        specifier: ^10.0.2
+        version: 10.0.2(typescript@5.9.3)
     devDependencies:
       '@starknet-start/typescript-config':
         specifier: workspace:^
@@ -229,8 +229,8 @@ importers:
         specifier: ^2.2.4
         version: 2.2.4
       starknet:
-        specifier: ^9.4.2
-        version: 9.4.2(typescript@5.9.3)(zod@3.25.76)
+        specifier: ^10.0.2
+        version: 10.0.2(typescript@5.9.3)(zod@3.25.76)
       viem:
         specifier: ^2.21.1
         version: 2.38.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -324,8 +324,8 @@ importers:
         specifier: ^4.1.2
         version: 4.4.1
       starknet:
-        specifier: ^9.4.2
-        version: 9.4.2(typescript@5.9.3)(zod@3.25.76)
+        specifier: ^10.0.2
+        version: 10.0.2(typescript@5.9.3)(zod@3.25.76)
       tsdown:
         specifier: ^0.16.8
         version: 0.16.8(typescript@5.9.3)
@@ -2371,11 +2371,11 @@ packages:
   '@starknet-io/get-starknet-wallets@5.0.0':
     resolution: {integrity: sha512-fuywFgoal4Al2KdFQCNTYgioK0ubu3cP+mM6OxE8ti78Nmd9ySlh78LwdKNXIp2Alq4kaQ5XMf6HMgkStCWhkw==}
 
-  '@starknet-io/types-js@0.10.0':
-    resolution: {integrity: sha512-7ALSydz6pq3YIOpq5a7OkkxqwJciMc9Nlph0OGjhcC3xX0xH30XgizmziLyYVN10oO9+BJk8M9KbJjpzdbtRSw==}
-
   '@starknet-io/types-js@0.10.1':
     resolution: {integrity: sha512-OhWK4YzgEzW0pKkynZH6U6T+3z0wAhO+8g/WhjQqZF9XQxscwthgOwsDi1AhOVWvzPZhyagbM8oclps45QWugA==}
+
+  '@starknet-io/types-js@0.10.2':
+    resolution: {integrity: sha512-AtUFPYdmo9DqVus++aBSoY9W13/2PZmillPr8/mXZjc+V0iYJ/QTmkTsbw+es2mnLeLhYWSymW9ivQzyyyKdog==}
 
   '@starknet-io/types-js@0.7.10':
     resolution: {integrity: sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==}
@@ -3934,6 +3934,7 @@ packages:
 
   get-starknet-core@4.0.0:
     resolution: {integrity: sha512-6pLmidQZkC3wZsrHY99grQHoGpuuXqkbSP65F8ov1/JsEI8DDLkhsAuLCKFzNOK56cJp+f1bWWfTJ57e9r5eqQ==}
+    deprecated: Package no longer supported. Please use @starknet-io/get-starknet-core
 
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
@@ -5414,12 +5415,12 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  starknet@8.9.2:
-    resolution: {integrity: sha512-+dp+o2w67fV6JyVOVkYeM1Ec71aORHc/JrF4VHLlfeGee0nLilooCQLE2u6hUcSGQG2x2/fvzkxYpIN+k1JBvA==}
+  starknet@10.0.2:
+    resolution: {integrity: sha512-bXdmvHiQ60XpwPb5mNOPfGg4MS+ppLiHj83yvhNnc+kDGyuYUUrnfZEU9O53/WFU8nP9XUtn0RwJpf47aafyKA==}
     engines: {node: '>=22'}
 
-  starknet@9.4.2:
-    resolution: {integrity: sha512-NFtg077DjddHUSh8sLZ5uB149LEF4NR90FuJ0oF7+zhce7l0oG9Ubqr3H4+jHm/ghHtV+yjlv1UhEoo4SBfILA==}
+  starknet@8.9.2:
+    resolution: {integrity: sha512-+dp+o2w67fV6JyVOVkYeM1Ec71aORHc/JrF4VHLlfeGee0nLilooCQLE2u6hUcSGQG2x2/fvzkxYpIN+k1JBvA==}
     engines: {node: '>=22'}
 
   statuses@2.0.1:
@@ -6348,11 +6349,11 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.1': {}
 
-  '@cartridge/connector@0.11.2(@starknet-react/core@4.0.1-beta.4(bufferutil@4.0.9)(get-starknet-core@4.0.0)(react@19.2.4)(starknet@9.4.2(typescript@5.9.3)(zod@3.25.76))(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@cartridge/connector@0.11.2(@starknet-react/core@4.0.1-beta.4(bufferutil@4.0.9)(get-starknet-core@4.0.0)(react@19.2.4)(starknet@10.0.2(typescript@5.9.3)(zod@3.25.76))(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@cartridge/controller': 0.11.2(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@starknet-io/get-starknet-wallet-standard': 5.0.0-beta.0(typescript@5.9.3)(zod@3.25.76)
-      '@starknet-react/core': 4.0.1-beta.4(bufferutil@4.0.9)(get-starknet-core@4.0.0)(react@19.2.4)(starknet@9.4.2(typescript@5.9.3)(zod@3.25.76))(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@starknet-react/core': 4.0.1-beta.4(bufferutil@4.0.9)(get-starknet-core@4.0.0)(react@19.2.4)(starknet@10.0.2(typescript@5.9.3)(zod@3.25.76))(typescript@5.9.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -8187,7 +8188,7 @@ snapshots:
 
   '@scure/bip32@1.7.0':
     dependencies:
-      '@noble/curves': 1.9.1
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
@@ -8369,9 +8370,9 @@ snapshots:
 
   '@starknet-io/get-starknet-wallets@5.0.0': {}
 
-  '@starknet-io/types-js@0.10.0': {}
-
   '@starknet-io/types-js@0.10.1': {}
+
+  '@starknet-io/types-js@0.10.2': {}
 
   '@starknet-io/types-js@0.7.10': {}
 
@@ -8383,7 +8384,7 @@ snapshots:
 
   '@starknet-react/chains@4.0.4': {}
 
-  '@starknet-react/core@4.0.1-beta.4(bufferutil@4.0.9)(get-starknet-core@4.0.0)(react@19.2.4)(starknet@9.4.2(typescript@5.9.3)(zod@3.25.76))(typescript@5.9.3)(utf-8-validate@5.0.10)':
+  '@starknet-react/core@4.0.1-beta.4(bufferutil@4.0.9)(get-starknet-core@4.0.0)(react@19.2.4)(starknet@10.0.2(typescript@5.9.3)(zod@3.25.76))(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@starknet-io/types-js': 0.7.10
       '@starknet-react/chains': 4.0.4
@@ -8392,7 +8393,7 @@ snapshots:
       eventemitter3: 5.0.4
       get-starknet-core: 4.0.0
       react: 19.2.4
-      starknet: 9.4.2(typescript@5.9.3)(zod@3.25.76)
+      starknet: 10.0.2(typescript@5.9.3)(zod@3.25.76)
       viem: 2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -12582,6 +12583,36 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  starknet@10.0.2(typescript@5.9.3):
+    dependencies:
+      '@noble/curves': 1.7.0
+      '@noble/hashes': 1.6.1
+      '@scure/base': 1.2.6
+      '@scure/starknet': 1.1.0
+      '@starknet-io/get-starknet-wallet-standard': 5.0.0(typescript@5.9.3)
+      '@starknet-io/starknet-types-0101': '@starknet-io/types-js@0.10.2'
+      '@starknet-io/starknet-types-09': '@starknet-io/types-js@0.9.2'
+      abi-wan-kanabi: 2.2.4
+      lossless-json: 4.3.0
+    transitivePeerDependencies:
+      - typescript
+      - zod
+
+  starknet@10.0.2(typescript@5.9.3)(zod@3.25.76):
+    dependencies:
+      '@noble/curves': 1.7.0
+      '@noble/hashes': 1.6.1
+      '@scure/base': 1.2.6
+      '@scure/starknet': 1.1.0
+      '@starknet-io/get-starknet-wallet-standard': 5.0.0(typescript@5.9.3)(zod@3.25.76)
+      '@starknet-io/starknet-types-0101': '@starknet-io/types-js@0.10.2'
+      '@starknet-io/starknet-types-09': '@starknet-io/types-js@0.9.2'
+      abi-wan-kanabi: 2.2.4
+      lossless-json: 4.3.0
+    transitivePeerDependencies:
+      - typescript
+      - zod
+
   starknet@8.9.2:
     dependencies:
       '@noble/curves': 1.7.0
@@ -12594,40 +12625,6 @@ snapshots:
       lossless-json: 4.3.0
       pako: 2.1.0
       ts-mixer: 6.0.4
-
-  starknet@9.4.2(typescript@5.9.3):
-    dependencies:
-      '@noble/curves': 1.7.0
-      '@noble/hashes': 1.6.1
-      '@scure/base': 1.2.6
-      '@scure/starknet': 1.1.0
-      '@starknet-io/get-starknet-wallet-standard': 5.0.0(typescript@5.9.3)
-      '@starknet-io/starknet-types-010': '@starknet-io/types-js@0.10.0'
-      '@starknet-io/starknet-types-09': '@starknet-io/types-js@0.9.2'
-      abi-wan-kanabi: 2.2.4
-      lossless-json: 4.3.0
-      pako: 2.1.0
-      ts-mixer: 6.0.4
-    transitivePeerDependencies:
-      - typescript
-      - zod
-
-  starknet@9.4.2(typescript@5.9.3)(zod@3.25.76):
-    dependencies:
-      '@noble/curves': 1.7.0
-      '@noble/hashes': 1.6.1
-      '@scure/base': 1.2.6
-      '@scure/starknet': 1.1.0
-      '@starknet-io/get-starknet-wallet-standard': 5.0.0(typescript@5.9.3)(zod@3.25.76)
-      '@starknet-io/starknet-types-010': '@starknet-io/types-js@0.10.0'
-      '@starknet-io/starknet-types-09': '@starknet-io/types-js@0.9.2'
-      abi-wan-kanabi: 2.2.4
-      lossless-json: 4.3.0
-      pako: 2.1.0
-      ts-mixer: 6.0.4
-    transitivePeerDependencies:
-      - typescript
-      - zod
 
   statuses@2.0.1: {}
 


### PR DESCRIPTION
### Summary

- Upgrade starknet.js peer dependency from `v8` to `v10`
- Upgrade `@starknet-io/types-js` from `0.8.x` to `0.10.x`
- Verified compatible with all existing connectors
  (argent, argentMobile, braavos, webwallet, injected,
  controller, keplr, fordefi, xverse, metamask)
- No public API changes; consumers on starknet v10 can
  now use starknetkit without peer-dep warnings