### PR TITLE
feat: support Starknet.js v10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           cache: true
 
       - name: Install dependencies
-        run: pnpm install --strict-peer-dependencies=false --frozen-lockfile
+        run: pnpm install --frozen-lockfile
       - name: Run check format
         run: pnpm format:check
       - name: Run lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           cache: true
 
       - name: Install dependencies
-        run: pnpm install --strict-peer-dependencies=false --no-frozen-lockfile
+        run: pnpm install --strict-peer-dependencies=false --frozen-lockfile
       - name: Run check format
         run: pnpm format:check
       - name: Run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           cache: true
 
       - name: Install dependencies
-        run: pnpm install --strict-peer-dependencies=false --frozen-lockfile
+        run: pnpm install --frozen-lockfile
       - name: Run build
         run: pnpm build
       - name: Setup git

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           cache: true
 
       - name: Install dependencies
-        run: pnpm install --strict-peer-dependencies=false --no-frozen-lockfile
+        run: pnpm install --strict-peer-dependencies=false --frozen-lockfile
       - name: Run build
         run: pnpm build
       - name: Setup git

--- a/change/@starknet-start-chains-starknet-v10.json
+++ b/change/@starknet-start-chains-starknet-v10.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "Release the coordinated Starknet.js v10 package set.",
+  "packageName": "@starknet-start/chains",
+  "email": "maintainers@starknet-start.dev",
+  "dependentChangeType": "major"
+}

--- a/change/@starknet-start-explorers-starknet-v10.json
+++ b/change/@starknet-start-explorers-starknet-v10.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "Release the coordinated Starknet.js v10 package set.",
+  "packageName": "@starknet-start/explorers",
+  "email": "maintainers@starknet-start.dev",
+  "dependentChangeType": "major"
+}

--- a/change/@starknet-start-providers-starknet-v10.json
+++ b/change/@starknet-start-providers-starknet-v10.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "BREAKING: require Starknet.js 10.0.2 and Node.js 22 or newer.",
+  "packageName": "@starknet-start/providers",
+  "email": "maintainers@starknet-start.dev",
+  "dependentChangeType": "major"
+}

--- a/change/@starknet-start-query-starknet-v10.json
+++ b/change/@starknet-start-query-starknet-v10.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "BREAKING: require Starknet.js 10.0.2 and Node.js 22 or newer, and migrate Starknet ID queries to the v10 API.",
+  "packageName": "@starknet-start/query",
+  "email": "maintainers@starknet-start.dev",
+  "dependentChangeType": "major"
+}

--- a/change/@starknet-start-react-starknet-v10.json
+++ b/change/@starknet-start-react-starknet-v10.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "BREAKING: require Starknet.js 10.0.2 and Node.js 22 or newer.",
+  "packageName": "@starknet-start/react",
+  "email": "maintainers@starknet-start.dev",
+  "dependentChangeType": "major"
+}

--- a/change/create-starknet-starknet-v10.json
+++ b/change/create-starknet-starknet-v10.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Generate Node.js 22 applications pinned to Starknet.js 10.0.2.",
+  "packageName": "create-starknet",
+  "email": "maintainers@starknet-start.dev",
+  "dependentChangeType": "patch"
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -29,7 +29,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "safe-stable-stringify": "^2.5.0",
-    "starknet": "^9.4.2",
+    "starknet": "10.0.2",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.17",
     "tw-animate-css": "^1.4.0",

--- a/packages/create-starknet/package.json
+++ b/packages/create-starknet/package.json
@@ -38,10 +38,13 @@
     "@starknet-start/typescript-config": "workspace:^",
     "@types/cross-spawn": "^6.0.2",
     "@types/fs-extra": "^11.0.1",
-    "@types/node": "^18.11.18",
+    "@types/node": "^22.0.0",
     "@types/prompts": "2.0.1",
     "@types/validate-npm-package-name": "^4.0.0",
     "tsup": "^8.0.2",
     "typescript": "^5.5.4"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/packages/create-starknet/src/templates/next/package.json
+++ b/packages/create-starknet/src/templates/next/package.json
@@ -13,20 +13,23 @@
     "@starknet-io/get-starknet-core": "^5.0.0",
     "@starknet-io/get-starknet-modal": "^5.0.0",
     "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
-    "@starknet-start/chains": "^1.0.1",
-    "@starknet-start/providers": "^1.0.1",
-    "@starknet-start/react": "^1.0.1",
+    "@starknet-start/chains": "2.0.0",
+    "@starknet-start/providers": "2.0.0",
+    "@starknet-start/react": "2.0.0",
     "next": "16.2.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "starknet": "^9.4.2"
+    "starknet": "10.0.2"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
-    "@types/node": "^20",
+    "@types/node": "^22",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19",
     "tailwindcss": "^4",
     "typescript": "^5"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/packages/create-starknet/src/templates/tanstack-start/package.json
+++ b/packages/create-starknet/src/templates/tanstack-start/package.json
@@ -17,16 +17,16 @@
     "@starknet-io/get-starknet-core": "^5.0.0",
     "@starknet-io/get-starknet-modal": "^5.0.0",
     "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
-    "@starknet-start/chains": "^1.0.1",
-    "@starknet-start/providers": "^1.0.1",
-    "@starknet-start/react": "^1.0.1",
+    "@starknet-start/chains": "2.0.0",
+    "@starknet-start/providers": "2.0.0",
+    "@starknet-start/react": "2.0.0",
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/react-router": "latest",
     "@tanstack/react-start": "latest",
     "@tanstack/router-plugin": "^1.132.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "starknet": "^9.4.2",
+    "starknet": "10.0.2",
     "tailwindcss": "^4.1.18"
   },
   "devDependencies": {
@@ -37,6 +37,9 @@
     "typescript": "^5.7.2",
     "vite": "^7.3.1",
     "vite-tsconfig-paths": "^5.1.4"
+  },
+  "engines": {
+    "node": ">=22"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/packages/explorers/tsconfig.json
+++ b/packages/explorers/tsconfig.json
@@ -4,5 +4,6 @@
     "baseUrl": ".",
     "rootDir": ".",
     "outDir": "dist"
-  }
+  },
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -38,12 +38,15 @@
   },
   "dependencies": {
     "@starknet-start/chains": "workspace:^",
-    "starknet": "^9.4.2"
+    "starknet": "10.0.2"
   },
   "devDependencies": {
     "@starknet-start/typescript-config": "workspace:^",
     "rimraf": "^4.1.2",
     "tsdown": "^0.16.8",
     "vitest": "^4.0.15"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/packages/providers/tsconfig.json
+++ b/packages/providers/tsconfig.json
@@ -4,5 +4,6 @@
     "baseUrl": ".",
     "rootDir": ".",
     "outDir": "dist"
-  }
+  },
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -42,10 +42,14 @@
   "devDependencies": {
     "@starknet-start/typescript-config": "workspace:^",
     "rimraf": "^4.1.2",
+    "starknet": "10.0.2",
     "tsdown": "^0.16.8",
     "vitest": "^4.0.15"
   },
   "peerDependencies": {
-    "starknet": "^9.4.2"
+    "starknet": "10.0.2"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/packages/query/src/stark-name.test.ts
+++ b/packages/query/src/stark-name.test.ts
@@ -1,0 +1,51 @@
+import type { ProviderInterface } from "starknet";
+
+import { StarknetIdImpl } from "starknet";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { starkNameQueryFn } from "./stark-name";
+
+vi.mock("starknet", () => ({
+  StarknetIdImpl: {
+    getStarkName: vi.fn(),
+  },
+}));
+
+const provider = {} as ProviderInterface;
+const address = "0x123";
+const mainnetNamingContract = "0x6ac597f8116f886fa1c97a23fa4e08299975ecaf6b598873ca6792b9bbfb678";
+
+describe("starkNameQueryFn", () => {
+  beforeEach(() => {
+    vi.mocked(StarknetIdImpl.getStarkName).mockReset();
+  });
+
+  it("requires an address", async () => {
+    await expect(starkNameQueryFn({ provider, network: "mainnet" })()).rejects.toThrow("address is required");
+  });
+
+  it("requires a network", async () => {
+    await expect(starkNameQueryFn({ provider, address })()).rejects.toThrow("network is required");
+  });
+
+  it("delegates to StarknetIdImpl with the default network contract", async () => {
+    vi.mocked(StarknetIdImpl.getStarkName).mockResolvedValue("alice.stark");
+
+    await expect(starkNameQueryFn({ provider, address, network: "mainnet" })()).resolves.toBe("alice.stark");
+
+    expect(StarknetIdImpl.getStarkName).toHaveBeenCalledWith(provider, address, mainnetNamingContract);
+  });
+
+  it("uses a custom naming contract when provided", async () => {
+    vi.mocked(StarknetIdImpl.getStarkName).mockResolvedValue("alice.stark");
+
+    await starkNameQueryFn({
+      provider,
+      address,
+      network: "mainnet",
+      contract: "0x456",
+    })();
+
+    expect(StarknetIdImpl.getStarkName).toHaveBeenCalledWith(provider, address, "0x456");
+  });
+});

--- a/packages/query/src/stark-name.ts
+++ b/packages/query/src/stark-name.ts
@@ -1,6 +1,6 @@
 import type { Address } from "@starknet-start/chains";
 
-import { Provider, type ProviderInterface } from "starknet";
+import { StarknetIdImpl, type ProviderInterface } from "starknet";
 
 export type StarkNameQueryKeyParams = {
   address?: string;
@@ -34,7 +34,6 @@ export function starkNameQueryFn({ address, contract, provider, network }: Stark
     if (!network) throw new Error("network is required");
 
     const namingContract = contract ?? StarknetIdNamingContract[network];
-    const p = new Provider(provider);
-    return await p.getStarkName(address as Address, namingContract);
+    return await StarknetIdImpl.getStarkName(provider, address as Address, namingContract);
   };
 }

--- a/packages/query/tsconfig.json
+++ b/packages/query/tsconfig.json
@@ -4,5 +4,6 @@
     "baseUrl": ".",
     "rootDir": ".",
     "outDir": "dist"
-  }
+  },
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,7 +29,7 @@
     "typecheck": "tsc --noEmit",
     "clean": "rimraf dist",
     "test": "vitest --fileParallelism=false",
-    "test:ci": "vitest run"
+    "test:ci": "vitest run --fileParallelism=false"
   },
   "dependencies": {
     "@starknet-io/types-js": "^0.10.1",
@@ -58,7 +58,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "rimraf": "^4.1.2",
-    "starknet": "^9.4.2",
+    "starknet": "10.0.2",
     "tsdown": "^0.16.8",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^4.0.15"
@@ -68,6 +68,9 @@
     "@starknet-io/get-starknet-modal": ">=5.0.0",
     "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
     "react": ">=19.0.0",
-    "starknet": ">=9.0.0"
+    "starknet": "10.0.2"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/packages/react/src/hooks/use-contract.test.ts
+++ b/packages/react/src/hooks/use-contract.test.ts
@@ -208,6 +208,7 @@ describe("useContract", () => {
             "name": [Function],
           },
           "classHash": undefined,
+          "defaultProvider": undefined,
           "estimateFee": {
             "name": [Function],
           },
@@ -222,17 +223,17 @@ describe("useContract", () => {
           "populateTransaction": {
             "name": [Function],
           },
-          "providerOrAccount": RpcProvider2 {
+          "providerOrAccount": RpcProvider {
             "channel": RpcChannel2 {
               "baseFetch": [Function],
               "batchClient": undefined,
               "blockIdentifier": "latest",
               "chainId": "0x534e5f5345504f4c4941",
-              "channelSpecVersion": "0.10.0",
+              "channelSpecVersion": "0.10.2",
               "headers": {
                 "Content-Type": "application/json",
               },
-              "id": "RPC0.10.0",
+              "id": "RPC0.10.2",
               "nodeUrl": "http://localhost:5050/rpc",
               "requestId": 0,
               "retries": 200,
@@ -240,7 +241,34 @@ describe("useContract", () => {
               "transactionRetryIntervalFallback": 5000,
               "waitMode": false,
             },
+            "fastWaitForTransaction": [Function],
+            "getAddressFromBrotherName": [Function],
+            "getAddressFromStarkName": [Function],
+            "getBrotherName": [Function],
+            "getBrotherProfile": [Function],
+            "getStarkName": [Function],
+            "getStarkProfile": [Function],
             "getStateUpdate": [Function],
+            "pluginManager": PluginManager {
+              "accountHooksList": [],
+              "providerHooksList": [],
+              "registeredPlugins": Map {
+                "starknet-id" => {
+                  "accountExtend": [Function],
+                  "extend": [Function],
+                  "name": "starknet-id",
+                },
+                "brother-id" => {
+                  "extend": [Function],
+                  "name": "brother-id",
+                },
+                "fast-execute" => {
+                  "accountExtend": [Function],
+                  "extend": [Function],
+                  "name": "fast-execute",
+                },
+              },
+            },
             "responseParser": RPCResponseParser {
               "resourceBoundsOverhead": undefined,
             },

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -4,5 +4,6 @@
     "baseUrl": ".",
     "rootDir": ".",
     "outDir": "dist"
-  }
+  },
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -51,13 +51,16 @@
     "@starknet-start/typescript-config": "workspace:^",
     "@vue/test-utils": "^2.4.6",
     "rimraf": "^4.1.2",
-    "starknet": "^9.4.2",
+    "starknet": "10.0.2",
     "tsup": "^8.0.2",
     "vitest": "^4.0.15",
     "vue": "^3.4.0"
   },
   "peerDependencies": {
-    "starknet": "^9.4.2",
+    "starknet": "10.0.2",
     "vue": "^3.4.0"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -1,9 +1,10 @@
 {
-  "extends": "@starknet-react/typescript-config/base.json",
+  "extends": "@starknet-start/typescript-config/base.json",
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": ".",
     "outDir": "dist"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
     dependencies:
       '@cartridge/connector':
         specifier: ^0.11.2
-        version: 0.11.2(@starknet-react/core@4.0.1-beta.4(bufferutil@4.0.9)(get-starknet-core@4.0.0)(react@19.2.4)(starknet@9.4.2(typescript@5.9.3)(zod@3.25.76))(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+        version: 0.11.2(@starknet-react/core@4.0.1-beta.4(bufferutil@4.0.9)(get-starknet-core@4.0.0)(react@19.2.4)(starknet@10.0.2(typescript@5.9.3)(zod@3.25.76))(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@cartridge/controller':
         specifier: ^0.11.2
         version: 0.11.2(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -87,8 +87,8 @@ importers:
         specifier: ^2.5.0
         version: 2.5.0
       starknet:
-        specifier: ^9.4.2
-        version: 9.4.2(typescript@5.9.3)(zod@3.25.76)
+        specifier: 10.0.2
+        version: 10.0.2(typescript@5.9.3)(zod@3.25.76)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -155,8 +155,8 @@ importers:
         specifier: ^11.0.1
         version: 11.0.4
       '@types/node':
-        specifier: ^18.11.18
-        version: 18.19.130
+        specifier: ^22.0.0
+        version: 22.7.5
       '@types/prompts':
         specifier: 2.0.1
         version: 2.0.1
@@ -195,8 +195,8 @@ importers:
         specifier: workspace:^
         version: link:../chains
       starknet:
-        specifier: ^9.4.2
-        version: 9.4.2(typescript@5.9.3)
+        specifier: 10.0.2
+        version: 10.0.2(typescript@5.9.3)
     devDependencies:
       '@starknet-start/typescript-config':
         specifier: workspace:^
@@ -228,9 +228,6 @@ importers:
       abi-wan-kanabi:
         specifier: ^2.2.4
         version: 2.2.4
-      starknet:
-        specifier: ^9.4.2
-        version: 9.4.2(typescript@5.9.3)(zod@3.25.76)
       viem:
         specifier: ^2.21.1
         version: 2.38.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -241,6 +238,9 @@ importers:
       rimraf:
         specifier: ^4.1.2
         version: 4.4.1
+      starknet:
+        specifier: 10.0.2
+        version: 10.0.2(typescript@5.9.3)(zod@3.25.76)
       tsdown:
         specifier: ^0.16.8
         version: 0.16.8(typescript@5.9.3)
@@ -324,8 +324,8 @@ importers:
         specifier: ^4.1.2
         version: 4.4.1
       starknet:
-        specifier: ^9.4.2
-        version: 9.4.2(typescript@5.9.3)(zod@3.25.76)
+        specifier: 10.0.2
+        version: 10.0.2(typescript@5.9.3)(zod@3.25.76)
       tsdown:
         specifier: ^0.16.8
         version: 0.16.8(typescript@5.9.3)
@@ -2371,11 +2371,11 @@ packages:
   '@starknet-io/get-starknet-wallets@5.0.0':
     resolution: {integrity: sha512-fuywFgoal4Al2KdFQCNTYgioK0ubu3cP+mM6OxE8ti78Nmd9ySlh78LwdKNXIp2Alq4kaQ5XMf6HMgkStCWhkw==}
 
-  '@starknet-io/types-js@0.10.0':
-    resolution: {integrity: sha512-7ALSydz6pq3YIOpq5a7OkkxqwJciMc9Nlph0OGjhcC3xX0xH30XgizmziLyYVN10oO9+BJk8M9KbJjpzdbtRSw==}
-
   '@starknet-io/types-js@0.10.1':
     resolution: {integrity: sha512-OhWK4YzgEzW0pKkynZH6U6T+3z0wAhO+8g/WhjQqZF9XQxscwthgOwsDi1AhOVWvzPZhyagbM8oclps45QWugA==}
+
+  '@starknet-io/types-js@0.10.2':
+    resolution: {integrity: sha512-AtUFPYdmo9DqVus++aBSoY9W13/2PZmillPr8/mXZjc+V0iYJ/QTmkTsbw+es2mnLeLhYWSymW9ivQzyyyKdog==}
 
   '@starknet-io/types-js@0.7.10':
     resolution: {integrity: sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==}
@@ -2763,9 +2763,6 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@18.19.130':
-    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
-
   '@types/node@22.7.5':
     resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
 
@@ -2809,6 +2806,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vanilla-extract/babel-plugin-debug-ids@1.2.2':
     resolution: {integrity: sha512-MeDWGICAF9zA/OZLOKwhoRlsUW+fiMwnfuOAqFVohL31Agj7Q/RBWAYweqjHLgFBCsdnr6XIfwjJnmb2znEWxw==}
@@ -3133,6 +3131,7 @@ packages:
   beachball@2.65.1:
     resolution: {integrity: sha512-tTbQop5ZXIGjhuIeCLjH14Z5c17YXyshJlKRbi9A+36++IzAL4qhsm2ttFELEdO5fXwa5tPjVSjsqSkClZfAVA==}
     engines: {node: '>=14.0.0'}
+    deprecated: Token auth with Yarn 4 + Linux is broken in this version (use 2.65.4+)
     hasBin: true
 
   bidi-js@1.0.3:
@@ -3934,6 +3933,7 @@ packages:
 
   get-starknet-core@4.0.0:
     resolution: {integrity: sha512-6pLmidQZkC3wZsrHY99grQHoGpuuXqkbSP65F8ov1/JsEI8DDLkhsAuLCKFzNOK56cJp+f1bWWfTJ57e9r5eqQ==}
+    deprecated: Package no longer supported. Please use @starknet-io/get-starknet-core
 
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
@@ -5414,12 +5414,12 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  starknet@8.9.2:
-    resolution: {integrity: sha512-+dp+o2w67fV6JyVOVkYeM1Ec71aORHc/JrF4VHLlfeGee0nLilooCQLE2u6hUcSGQG2x2/fvzkxYpIN+k1JBvA==}
+  starknet@10.0.2:
+    resolution: {integrity: sha512-bXdmvHiQ60XpwPb5mNOPfGg4MS+ppLiHj83yvhNnc+kDGyuYUUrnfZEU9O53/WFU8nP9XUtn0RwJpf47aafyKA==}
     engines: {node: '>=22'}
 
-  starknet@9.4.2:
-    resolution: {integrity: sha512-NFtg077DjddHUSh8sLZ5uB149LEF4NR90FuJ0oF7+zhce7l0oG9Ubqr3H4+jHm/ghHtV+yjlv1UhEoo4SBfILA==}
+  starknet@8.9.2:
+    resolution: {integrity: sha512-+dp+o2w67fV6JyVOVkYeM1Ec71aORHc/JrF4VHLlfeGee0nLilooCQLE2u6hUcSGQG2x2/fvzkxYpIN+k1JBvA==}
     engines: {node: '>=22'}
 
   statuses@2.0.1:
@@ -5593,6 +5593,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -5696,9 +5697,6 @@ packages:
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
-
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
@@ -6348,11 +6346,11 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.1': {}
 
-  '@cartridge/connector@0.11.2(@starknet-react/core@4.0.1-beta.4(bufferutil@4.0.9)(get-starknet-core@4.0.0)(react@19.2.4)(starknet@9.4.2(typescript@5.9.3)(zod@3.25.76))(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@cartridge/connector@0.11.2(@starknet-react/core@4.0.1-beta.4(bufferutil@4.0.9)(get-starknet-core@4.0.0)(react@19.2.4)(starknet@10.0.2(typescript@5.9.3)(zod@3.25.76))(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@cartridge/controller': 0.11.2(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@starknet-io/get-starknet-wallet-standard': 5.0.0-beta.0(typescript@5.9.3)(zod@3.25.76)
-      '@starknet-react/core': 4.0.1-beta.4(bufferutil@4.0.9)(get-starknet-core@4.0.0)(react@19.2.4)(starknet@9.4.2(typescript@5.9.3)(zod@3.25.76))(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@starknet-react/core': 4.0.1-beta.4(bufferutil@4.0.9)(get-starknet-core@4.0.0)(react@19.2.4)(starknet@10.0.2(typescript@5.9.3)(zod@3.25.76))(typescript@5.9.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -8369,9 +8367,9 @@ snapshots:
 
   '@starknet-io/get-starknet-wallets@5.0.0': {}
 
-  '@starknet-io/types-js@0.10.0': {}
-
   '@starknet-io/types-js@0.10.1': {}
+
+  '@starknet-io/types-js@0.10.2': {}
 
   '@starknet-io/types-js@0.7.10': {}
 
@@ -8383,7 +8381,7 @@ snapshots:
 
   '@starknet-react/chains@4.0.4': {}
 
-  '@starknet-react/core@4.0.1-beta.4(bufferutil@4.0.9)(get-starknet-core@4.0.0)(react@19.2.4)(starknet@9.4.2(typescript@5.9.3)(zod@3.25.76))(typescript@5.9.3)(utf-8-validate@5.0.10)':
+  '@starknet-react/core@4.0.1-beta.4(bufferutil@4.0.9)(get-starknet-core@4.0.0)(react@19.2.4)(starknet@10.0.2(typescript@5.9.3)(zod@3.25.76))(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@starknet-io/types-js': 0.7.10
       '@starknet-react/chains': 4.0.4
@@ -8392,7 +8390,7 @@ snapshots:
       eventemitter3: 5.0.4
       get-starknet-core: 4.0.0
       react: 19.2.4
-      starknet: 9.4.2(typescript@5.9.3)(zod@3.25.76)
+      starknet: 10.0.2(typescript@5.9.3)(zod@3.25.76)
       viem: 2.48.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -8657,7 +8655,7 @@ snapshots:
 
   '@types/cross-spawn@6.0.6':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 22.7.5
 
   '@types/d3-array@3.2.2': {}
 
@@ -8791,7 +8789,7 @@ snapshots:
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 18.19.130
+      '@types/node': 22.7.5
 
   '@types/geojson@7946.0.16': {}
 
@@ -8801,7 +8799,7 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 22.7.5
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -8810,10 +8808,6 @@ snapshots:
   '@types/mdx@2.0.13': {}
 
   '@types/ms@2.1.0': {}
-
-  '@types/node@18.19.130':
-    dependencies:
-      undici-types: 5.26.5
 
   '@types/node@22.7.5':
     dependencies:
@@ -10425,7 +10419,7 @@ snapshots:
 
   eval@0.1.8:
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 22.7.5
       require-like: 0.1.2
 
   eventemitter3@5.0.1: {}
@@ -12582,6 +12576,36 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  starknet@10.0.2(typescript@5.9.3):
+    dependencies:
+      '@noble/curves': 1.7.0
+      '@noble/hashes': 1.6.1
+      '@scure/base': 1.2.6
+      '@scure/starknet': 1.1.0
+      '@starknet-io/get-starknet-wallet-standard': 5.0.0(typescript@5.9.3)
+      '@starknet-io/starknet-types-0101': '@starknet-io/types-js@0.10.2'
+      '@starknet-io/starknet-types-09': '@starknet-io/types-js@0.9.2'
+      abi-wan-kanabi: 2.2.4
+      lossless-json: 4.3.0
+    transitivePeerDependencies:
+      - typescript
+      - zod
+
+  starknet@10.0.2(typescript@5.9.3)(zod@3.25.76):
+    dependencies:
+      '@noble/curves': 1.7.0
+      '@noble/hashes': 1.6.1
+      '@scure/base': 1.2.6
+      '@scure/starknet': 1.1.0
+      '@starknet-io/get-starknet-wallet-standard': 5.0.0(typescript@5.9.3)(zod@3.25.76)
+      '@starknet-io/starknet-types-0101': '@starknet-io/types-js@0.10.2'
+      '@starknet-io/starknet-types-09': '@starknet-io/types-js@0.9.2'
+      abi-wan-kanabi: 2.2.4
+      lossless-json: 4.3.0
+    transitivePeerDependencies:
+      - typescript
+      - zod
+
   starknet@8.9.2:
     dependencies:
       '@noble/curves': 1.7.0
@@ -12594,40 +12618,6 @@ snapshots:
       lossless-json: 4.3.0
       pako: 2.1.0
       ts-mixer: 6.0.4
-
-  starknet@9.4.2(typescript@5.9.3):
-    dependencies:
-      '@noble/curves': 1.7.0
-      '@noble/hashes': 1.6.1
-      '@scure/base': 1.2.6
-      '@scure/starknet': 1.1.0
-      '@starknet-io/get-starknet-wallet-standard': 5.0.0(typescript@5.9.3)
-      '@starknet-io/starknet-types-010': '@starknet-io/types-js@0.10.0'
-      '@starknet-io/starknet-types-09': '@starknet-io/types-js@0.9.2'
-      abi-wan-kanabi: 2.2.4
-      lossless-json: 4.3.0
-      pako: 2.1.0
-      ts-mixer: 6.0.4
-    transitivePeerDependencies:
-      - typescript
-      - zod
-
-  starknet@9.4.2(typescript@5.9.3)(zod@3.25.76):
-    dependencies:
-      '@noble/curves': 1.7.0
-      '@noble/hashes': 1.6.1
-      '@scure/base': 1.2.6
-      '@scure/starknet': 1.1.0
-      '@starknet-io/get-starknet-wallet-standard': 5.0.0(typescript@5.9.3)(zod@3.25.76)
-      '@starknet-io/starknet-types-010': '@starknet-io/types-js@0.10.0'
-      '@starknet-io/starknet-types-09': '@starknet-io/types-js@0.9.2'
-      abi-wan-kanabi: 2.2.4
-      lossless-json: 4.3.0
-      pako: 2.1.0
-      ts-mixer: 6.0.4
-    transitivePeerDependencies:
-      - typescript
-      - zod
 
   statuses@2.0.1: {}
 
@@ -12893,8 +12883,6 @@ snapshots:
       quansync: 0.2.11
 
   uncrypto@0.1.3: {}
-
-  undici-types@5.26.5: {}
 
   undici-types@6.19.8: {}
 


### PR DESCRIPTION
## Summary
- migrate the coordinated Starknet Start package set to exact Starknet.js 10.0.2 and Node.js 22
- prepare major 2.0.0 releases for chains, explorers, providers, query, and react through Beachball
- migrate Starknet ID lookup to the v10 API and update create-starknet templates to the coordinated 2.0.0 packages
- enforce strict frozen installs and isolate package build outputs from concurrent typechecking

## Why
Downstream Dojo 2, Arcade, and Cartridge Controller consumers otherwise install Starknet.js 9 transitively through providers/query alongside Starknet.js 10. This coordinated release removes that mixed graph.

## Validation
- pnpm install --frozen-lockfile
- format, lint, and forced concurrent typecheck
- 63 tests passed, 3 skipped
- full package and documentation build
- Beachball check and post-bump package metadata validation
- generated Next.js and TanStack Start production builds
- clean npm and pnpm packed consumers resolve exactly one Starknet.js 10.0.2

Bun 1.3.5 hangs only in the prepublication fixture while resolving mutually dependent unpublished 2.0.0 tarballs; npm/pnpm consumers and all package builds pass.